### PR TITLE
docs: document selected tech stack and repository overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# shophub
-ShopHub web app — panel for managing shop deployments on Kubernetes
+# ShopHub
+
+ShopHub is a platform that lets users deploy and manage their own e-commerce shops on a Kubernetes cluster. A signed-in user creates a shop through an admin panel, and the platform provisions the required infrastructure (application replicas, database, notifications channel, payment wallet) via a custom Kubernetes operator.
+
+## Role of this repository
+
+This repository contains the ShopHub web application: the admin panel users interact with to manage their shops. A signed-in user can create a new shop, change its configuration (name, availability tier, wallet address, database type), and delete shops they own. Per-tenant Shop applications live in a separate repository.
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Backend runtime | Node.js 20 |
+| Backend language | TypeScript |
+| Backend framework | NestJS |
+| Frontend framework | Next.js (React) |
+| Web3 (optional auth) | wagmi + viem + Metamask (Ethereum Sepolia testnet) |
+| Database | PostgreSQL |
+| Container registry | GitHub Container Registry (`ghcr.io/shophub-devops`) |
+| Local Kubernetes | kind |
+
+## Running locally
+
+To be documented once the backend and frontend are initialized. See the issues in this repository for the M1 task list.
+
+## Related repositories
+
+| Repository | Purpose |
+|---|---|
+| [shop](https://github.com/ShopHub-DevOps/shop) | Per-tenant shop application deployed by the operator |
+| [shop-operator](https://github.com/ShopHub-DevOps/shop-operator) | Kubernetes operator that provisions shops on behalf of ShopHub |
+| [helm-charts](https://github.com/ShopHub-DevOps/helm-charts) | Helm charts for all services |
+| [kube-state](https://github.com/ShopHub-DevOps/kube-state) | Declarative cluster state |
+
+## License
+
+MIT. See [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary
                                                                                            
Replace the one-line README placeholder with a proper repository overview describing ShopHub's role as the platform panel, the chosen tech stack, and how this repo relates to the rest of the system.                                   
                                                                                            
## Related issue                            
                                                                                            
Refs #1                                                   
                                                                                            
(The repo's setup milestone originally tracked a separate "docs: document selected tech stack and repository overview" issue but that issue was removed; the work is captured here directly. The tech stack decision in #1 is the upstream context this PR documents.)
                                                                                            
## Spec reference
                                                                                            
Section 5.1 (project documentation) and section 1.x (ShopHub platform overview).
                                        
## Changes
                                                                                            
- Open with a paragraph describing the platform: signed-in users create shops through the panel and the system provisions per-tenant infrastructure (application replicas, database, Discord channel, payment wallet) via a custom Kubernetes operator
- Add a "Role of this repository" section clarifying that this repo holds the admin panel; per-tenant Shop applications live in the `shop` repo
- Add a "Tech stack" table covering backend (Node.js 20 + TypeScript + NestJS), frontend (Next.js + React), optional Web3 auth (wagmi + viem + Metamask on Ethereum Sepolia), database (PostgreSQL), container registry (GHCR), local Kubernetes (kind)                   
- Add a placeholder "Running locally" section pointing readers to the M1 issues until backend and frontend are initialized                                                        
- Add a "Related repositories" section linking to `shop`, `shop-operator`, `helm-charts`, and `kube-state`                                                                            
- Add a License section referencing the MIT LICENSE file  
                                            
## Testing                                                                                  
 
Documentation-only change. Verified locally by rendering the README in a Markdown preview and checking that all cross-repo links resolve to the correct `ShopHub-DevOps` repositories.
                                                                                            
## Checklist                                                                                
 
- [ ] Commits follow Conventional Commits format - the existing commit's subject ("Update README.md...") does not have the `docs:` prefix; the squash merge with the PR title `docs: document selected tech stack and repository overview` produces a properly formatted commit on `develop`                                                                                
- [x] Tests added or updated - n/a, documentation-only change
- [x] Documentation updated if relevant                                                     
- [x] Linked to related issue  