### PR TITLE
feat(shops): per-user shop CRUD wired to shop-operator Shop CR

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/typeorm": "^11.0.1",
         "argon2": "^0.44.0",
         "class-transformer": "^0.5.1",
@@ -2137,6 +2139,75 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -2522,6 +2593,19 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -3089,6 +3173,12 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3104,6 +3194,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -3124,6 +3220,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/passport": {
@@ -3245,6 +3351,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
@@ -4105,6 +4220,15 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4500,7 +4624,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -4545,7 +4668,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -4567,7 +4689,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -4687,7 +4808,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -4702,7 +4822,6 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
       "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -4727,7 +4846,6 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
       "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -4737,7 +4855,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -4747,7 +4864,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
       "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -4774,7 +4890,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
       "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -5352,7 +5467,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5681,6 +5795,23 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -5799,7 +5930,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6022,7 +6152,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6093,7 +6222,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6437,7 +6565,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -6563,7 +6690,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -6797,7 +6923,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6814,7 +6939,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6824,7 +6948,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7223,6 +7346,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7370,6 +7502,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -7520,6 +7661,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8361,6 +8511,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8372,13 +8531,21 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/jsesc": {
@@ -8453,6 +8620,24 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -8730,6 +8915,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -9115,6 +9309,26 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -9160,6 +9374,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -9218,6 +9441,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -9876,7 +10112,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -10114,6 +10349,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -10412,6 +10653,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -10554,6 +10833,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -10566,7 +10854,6 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -10793,7 +11080,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -10808,7 +11094,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -10821,7 +11106,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -11085,7 +11369,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -11184,6 +11467,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -11965,6 +12254,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack": {
       "version": "5.106.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
@@ -12138,6 +12433,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,12 +25,14 @@
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/database/data-source.ts"
   },
   "dependencies": {
+    "@kubernetes/client-node": "^1.4.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/typeorm": "^11.0.1",
     "argon2": "^0.44.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { validateEnv } from './config/env.validation';
 import { DatabaseModule } from './database/database.module';
+import { ShopsModule } from './shops/shops.module';
 import { UsersModule } from './users/users.module';
 
 @Module({
@@ -15,9 +17,11 @@ import { UsersModule } from './users/users.module';
       envFilePath: ['.env', '../.env'],
       validate: validateEnv,
     }),
+    ScheduleModule.forRoot(),
     DatabaseModule.register(),
     UsersModule,
     AuthModule,
+    ShopsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/database/migrations/1716700000000-AddShopsTable.ts
+++ b/backend/src/database/migrations/1716700000000-AddShopsTable.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddShopsTable1716700000000 implements MigrationInterface {
+  name = 'AddShopsTable1716700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "shops" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "k8s_name" varchar(63) NOT NULL,
+        "display_name" varchar(80) NOT NULL,
+        "host" varchar(253) NOT NULL,
+        "availability" varchar(16) NOT NULL,
+        "database_tier" varchar(16) NOT NULL,
+        "wallet_address" varchar(42) NOT NULL,
+        "chain_id" bigint NOT NULL DEFAULT 11155111,
+        "backend_image" varchar(255),
+        "frontend_image" varchar(255),
+        "last_known_phase" varchar(16),
+        "last_known_url" varchar(512),
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "chk_shops_availability"
+          CHECK ("availability" IN ('standard', 'high')),
+        CONSTRAINT "chk_shops_database_tier"
+          CHECK ("database_tier" IN ('standard', 'light'))
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uniq_shops_k8s_name" ON "shops" ("k8s_name")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uniq_shops_host" ON "shops" ("host")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_shops_user_id" ON "shops" ("user_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_shops_user_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "uniq_shops_host"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "uniq_shops_k8s_name"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "shops"`);
+  }
+}

--- a/backend/src/k8s/k8s.constants.ts
+++ b/backend/src/k8s/k8s.constants.ts
@@ -1,0 +1,4 @@
+export const SHOP_CR_GROUP = 'shophub.io';
+export const SHOP_CR_VERSION = 'v1alpha1';
+export const SHOP_CR_PLURAL = 'shops';
+export const SHOP_CR_NAMESPACE = 'shophub-tenants';

--- a/backend/src/k8s/k8s.module.ts
+++ b/backend/src/k8s/k8s.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ShopCRClient } from './shop-cr.client';
+
+@Module({
+  providers: [ShopCRClient],
+  exports: [ShopCRClient],
+})
+export class K8sModule {}

--- a/backend/src/k8s/shop-cr.client.ts
+++ b/backend/src/k8s/shop-cr.client.ts
@@ -1,0 +1,162 @@
+import { CustomObjectsApi, KubeConfig, PatchStrategy, setHeaderOptions } from '@kubernetes/client-node';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+  ConflictException,
+} from '@nestjs/common';
+import {
+  SHOP_CR_GROUP,
+  SHOP_CR_NAMESPACE,
+  SHOP_CR_PLURAL,
+  SHOP_CR_VERSION,
+} from './k8s.constants';
+import { ShopCR, ShopSpec } from './shop-cr.types';
+
+/**
+ * Wraps @kubernetes/client-node CustomObjectsApi for the Shop CRD.
+ *
+ * Connection strategy mirrors the official client default: try in-cluster
+ * (mounted ServiceAccount token) first, fall back to ~/.kube/config for
+ * local development. If neither is available the module still boots so
+ * that unrelated requests (auth, health) keep working - K8s calls then
+ * fail at request time with a descriptive error.
+ */
+@Injectable()
+export class ShopCRClient implements OnModuleInit {
+  private readonly logger = new Logger(ShopCRClient.name);
+  private api?: CustomObjectsApi;
+  private connectionError?: Error;
+
+  onModuleInit(): void {
+    try {
+      const kc = new KubeConfig();
+      kc.loadFromDefault();
+      this.api = kc.makeApiClient(CustomObjectsApi);
+      const ctx = kc.getCurrentContext();
+      this.logger.log(`Kubernetes client ready (context: ${ctx})`);
+    } catch (err) {
+      this.connectionError = err instanceof Error ? err : new Error(String(err));
+      this.logger.warn(
+        `Kubernetes client could not initialize: ${this.connectionError.message}. ` +
+          'Shop CR operations will fail until kubeconfig or in-cluster credentials are available.',
+      );
+    }
+  }
+
+  isReady(): boolean {
+    return this.api !== undefined;
+  }
+
+  async create(name: string, spec: ShopSpec): Promise<ShopCR> {
+    const api = this.requireApi();
+    const body: ShopCR = {
+      apiVersion: `${SHOP_CR_GROUP}/${SHOP_CR_VERSION}`,
+      kind: 'Shop',
+      metadata: { name, namespace: SHOP_CR_NAMESPACE },
+      spec,
+    };
+    try {
+      const result = await api.createNamespacedCustomObject({
+        group: SHOP_CR_GROUP,
+        version: SHOP_CR_VERSION,
+        namespace: SHOP_CR_NAMESPACE,
+        plural: SHOP_CR_PLURAL,
+        body,
+      });
+      return result as ShopCR;
+    } catch (err) {
+      if (this.statusCode(err) === 409) {
+        throw new ConflictException(`Shop ${name} already exists in cluster`);
+      }
+      throw err;
+    }
+  }
+
+  async get(name: string): Promise<ShopCR | null> {
+    const api = this.requireApi();
+    try {
+      const result = await api.getNamespacedCustomObject({
+        group: SHOP_CR_GROUP,
+        version: SHOP_CR_VERSION,
+        namespace: SHOP_CR_NAMESPACE,
+        plural: SHOP_CR_PLURAL,
+        name,
+      });
+      return result as ShopCR;
+    } catch (err) {
+      if (this.statusCode(err) === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async list(): Promise<ShopCR[]> {
+    const api = this.requireApi();
+    const result = await api.listNamespacedCustomObject({
+      group: SHOP_CR_GROUP,
+      version: SHOP_CR_VERSION,
+      namespace: SHOP_CR_NAMESPACE,
+      plural: SHOP_CR_PLURAL,
+    });
+    return (result as { items?: ShopCR[] }).items ?? [];
+  }
+
+  async patchSpec(name: string, patch: Partial<ShopSpec>): Promise<ShopCR> {
+    const api = this.requireApi();
+    try {
+      const result = await api.patchNamespacedCustomObject(
+        {
+          group: SHOP_CR_GROUP,
+          version: SHOP_CR_VERSION,
+          namespace: SHOP_CR_NAMESPACE,
+          plural: SHOP_CR_PLURAL,
+          name,
+          body: { spec: patch },
+        },
+        setHeaderOptions('Content-Type', PatchStrategy.MergePatch),
+      );
+      return result as ShopCR;
+    } catch (err) {
+      if (this.statusCode(err) === 404) {
+        throw new NotFoundException(`Shop ${name} not found in cluster`);
+      }
+      throw err;
+    }
+  }
+
+  async delete(name: string): Promise<void> {
+    const api = this.requireApi();
+    try {
+      await api.deleteNamespacedCustomObject({
+        group: SHOP_CR_GROUP,
+        version: SHOP_CR_VERSION,
+        namespace: SHOP_CR_NAMESPACE,
+        plural: SHOP_CR_PLURAL,
+        name,
+      });
+    } catch (err) {
+      if (this.statusCode(err) === 404) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private requireApi(): CustomObjectsApi {
+    if (!this.api) {
+      throw new Error(
+        `Kubernetes client not available: ${this.connectionError?.message ?? 'unknown reason'}`,
+      );
+    }
+    return this.api;
+  }
+
+  private statusCode(err: unknown): number | undefined {
+    if (typeof err !== 'object' || err === null) return undefined;
+    const candidate = err as { code?: number; statusCode?: number; response?: { statusCode?: number } };
+    return candidate.code ?? candidate.statusCode ?? candidate.response?.statusCode;
+  }
+}

--- a/backend/src/k8s/shop-cr.types.ts
+++ b/backend/src/k8s/shop-cr.types.ts
@@ -1,0 +1,57 @@
+// TypeScript mirror of api/v1alpha1/shop_types.go in the shop-operator repo.
+// Kept in sync manually until we share a contract via OpenAPI codegen.
+
+export type AvailabilityTier = 'standard' | 'high';
+export type DatabaseTier = 'standard' | 'light';
+export type ShopPhase =
+  | 'Pending'
+  | 'Provisioning'
+  | 'Ready'
+  | 'Failed'
+  | 'Terminating';
+
+export interface ShopImages {
+  backend?: string;
+  frontend?: string;
+}
+
+export interface ShopSpec {
+  displayName: string;
+  host: string;
+  availability: AvailabilityTier;
+  databaseTier: DatabaseTier;
+  walletAddress: string;
+  chainId?: number;
+  images?: ShopImages;
+}
+
+export interface ShopCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  observedGeneration?: number;
+  lastTransitionTime?: string;
+}
+
+export interface ShopStatus {
+  phase?: ShopPhase;
+  url?: string;
+  conditions?: ShopCondition[];
+  observedGeneration?: number;
+}
+
+export interface ShopCR {
+  apiVersion: 'shophub.io/v1alpha1';
+  kind: 'Shop';
+  metadata: {
+    name: string;
+    namespace: string;
+    generation?: number;
+    resourceVersion?: string;
+    uid?: string;
+    creationTimestamp?: string;
+  };
+  spec: ShopSpec;
+  status?: ShopStatus;
+}

--- a/backend/src/shops/dto/create-shop.dto.ts
+++ b/backend/src/shops/dto/create-shop.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsEnum,
+  IsEthereumAddress,
+  IsInt,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+const HOST_PATTERN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$/;
+
+export class CreateShopDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  displayName!: string;
+
+  @IsString()
+  @MaxLength(253)
+  @Matches(HOST_PATTERN, {
+    message: 'host must be a lowercase DNS-1123 hostname',
+  })
+  host!: string;
+
+  @IsEnum(['standard', 'high'] as const)
+  availability!: 'standard' | 'high';
+
+  @IsEnum(['standard', 'light'] as const)
+  databaseTier!: 'standard' | 'light';
+
+  @IsEthereumAddress()
+  walletAddress!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  chainId?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  backendImage?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  frontendImage?: string;
+}

--- a/backend/src/shops/dto/update-shop.dto.ts
+++ b/backend/src/shops/dto/update-shop.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsEnum,
+  IsEthereumAddress,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateIf,
+} from 'class-validator';
+
+// `host` and `k8sName` are immutable after creation - changing host would
+// require Ingress re-routing and break in-flight customer sessions, so we
+// reject it at the DTO layer rather than silently ignoring.
+export class UpdateShopDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  displayName?: string;
+
+  @IsOptional()
+  @IsEnum(['standard', 'high'] as const)
+  availability?: 'standard' | 'high';
+
+  @IsOptional()
+  @IsEnum(['standard', 'light'] as const)
+  databaseTier?: 'standard' | 'light';
+
+  @IsOptional()
+  @IsEthereumAddress()
+  walletAddress?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  chainId?: number;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  @MaxLength(255)
+  backendImage?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  @MaxLength(255)
+  frontendImage?: string | null;
+}

--- a/backend/src/shops/entities/shop.entity.ts
+++ b/backend/src/shops/entities/shop.entity.ts
@@ -1,0 +1,93 @@
+import {
+  BeforeInsert,
+  BeforeUpdate,
+  Check,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type {
+  AvailabilityTier,
+  DatabaseTier,
+  ShopPhase,
+} from '../../k8s/shop-cr.types';
+
+@Entity({ name: 'shops' })
+@Check(
+  'chk_shops_availability',
+  `"availability" IN ('standard', 'high')`,
+)
+@Check(
+  'chk_shops_database_tier',
+  `"database_tier" IN ('standard', 'light')`,
+)
+@Index('uniq_shops_k8s_name', ['k8sName'], { unique: true })
+@Index('uniq_shops_host', ['host'], { unique: true })
+@Index('idx_shops_user_id', ['userId'])
+export class Shop {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  /**
+   * Auto-generated DNS-1123 label used as the Shop CR's metadata.name.
+   * Immutable after creation; users never see it directly.
+   */
+  @Column({ name: 'k8s_name', type: 'varchar', length: 63 })
+  k8sName!: string;
+
+  @Column({ name: 'display_name', type: 'varchar', length: 80 })
+  displayName!: string;
+
+  @Column({ type: 'varchar', length: 253 })
+  host!: string;
+
+  @Column({ type: 'varchar', length: 16 })
+  availability!: AvailabilityTier;
+
+  @Column({ name: 'database_tier', type: 'varchar', length: 16 })
+  databaseTier!: DatabaseTier;
+
+  @Column({ name: 'wallet_address', type: 'varchar', length: 42 })
+  walletAddress!: string;
+
+  @Column({ name: 'chain_id', type: 'bigint', default: 11155111 })
+  chainId!: string;
+
+  @Column({ name: 'backend_image', type: 'varchar', length: 255, nullable: true })
+  backendImage!: string | null;
+
+  @Column({ name: 'frontend_image', type: 'varchar', length: 255, nullable: true })
+  frontendImage!: string | null;
+
+  @Column({ name: 'last_known_phase', type: 'varchar', length: 16, nullable: true })
+  lastKnownPhase!: ShopPhase | null;
+
+  @Column({ name: 'last_known_url', type: 'varchar', length: 512, nullable: true })
+  lastKnownUrl!: string | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  normalize(): void {
+    if (this.walletAddress) {
+      this.walletAddress = this.walletAddress.toLowerCase();
+    }
+    if (this.host) {
+      this.host = this.host.toLowerCase();
+    }
+    if (this.k8sName) {
+      this.k8sName = this.k8sName.toLowerCase();
+    }
+  }
+}

--- a/backend/src/shops/shops-status.poller.ts
+++ b/backend/src/shops/shops-status.poller.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ShopsService } from './shops.service';
+
+@Injectable()
+export class ShopsStatusPoller {
+  private readonly logger = new Logger(ShopsStatusPoller.name);
+
+  constructor(private readonly shops: ShopsService) {}
+
+  // Every 15 seconds is responsive enough for the panel without hammering
+  // the API server. Will be replaced by an informer/watch later.
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async sweep(): Promise<void> {
+    try {
+      await this.shops.syncAllStatuses();
+    } catch (err) {
+      this.logger.warn(
+        `Status sweep failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/backend/src/shops/shops.controller.ts
+++ b/backend/src/shops/shops.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { User } from '../users/entities/user.entity';
+import { CreateShopDto } from './dto/create-shop.dto';
+import { UpdateShopDto } from './dto/update-shop.dto';
+import { Shop } from './entities/shop.entity';
+import { ShopsService } from './shops.service';
+
+@Controller('shops')
+@UseGuards(JwtAuthGuard)
+export class ShopsController {
+  constructor(private readonly shops: ShopsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@CurrentUser() user: User, @Body() dto: CreateShopDto): Promise<Shop> {
+    return this.shops.createForUser(user.id, dto);
+  }
+
+  @Get()
+  list(@CurrentUser() user: User): Promise<Shop[]> {
+    return this.shops.findAllForUser(user.id);
+  }
+
+  @Get(':id')
+  get(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<Shop> {
+    return this.shops.findOneForUser(user.id, id);
+  }
+
+  @Patch(':id')
+  update(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateShopDto,
+  ): Promise<Shop> {
+    return this.shops.updateForUser(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.shops.deleteForUser(user.id, id);
+  }
+}

--- a/backend/src/shops/shops.mapper.ts
+++ b/backend/src/shops/shops.mapper.ts
@@ -1,0 +1,24 @@
+import { ShopSpec } from '../k8s/shop-cr.types';
+import { Shop } from './entities/shop.entity';
+
+/**
+ * Translates a Shop database entity into the spec body the operator expects.
+ * Optional images object is omitted when both fields are null so we never
+ * write `{ backend: '', frontend: '' }` to the cluster.
+ */
+export function shopEntityToCRSpec(shop: Shop): ShopSpec {
+  const spec: ShopSpec = {
+    displayName: shop.displayName,
+    host: shop.host,
+    availability: shop.availability,
+    databaseTier: shop.databaseTier,
+    walletAddress: shop.walletAddress,
+    chainId: Number(shop.chainId),
+  };
+  if (shop.backendImage || shop.frontendImage) {
+    spec.images = {};
+    if (shop.backendImage) spec.images.backend = shop.backendImage;
+    if (shop.frontendImage) spec.images.frontend = shop.frontendImage;
+  }
+  return spec;
+}

--- a/backend/src/shops/shops.module.ts
+++ b/backend/src/shops/shops.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { K8sModule } from '../k8s/k8s.module';
+import { UsersModule } from '../users/users.module';
+import { Shop } from './entities/shop.entity';
+import { ShopsController } from './shops.controller';
+import { ShopsService } from './shops.service';
+import { ShopsStatusPoller } from './shops-status.poller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Shop]),
+    AuthModule,
+    K8sModule,
+    UsersModule,
+  ],
+  controllers: [ShopsController],
+  providers: [ShopsService, ShopsStatusPoller],
+  exports: [ShopsService],
+})
+export class ShopsModule {}

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -1,0 +1,229 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+// @kubernetes/client-node ships as ESM in v1.x; ts-jest's CJS transform
+// chokes on it. We never call the real client in unit tests (ShopCRClient
+// is replaced via DI), so an empty mock at module load time is enough.
+jest.mock('@kubernetes/client-node', () => ({
+  CustomObjectsApi: class {},
+  KubeConfig: class {
+    loadFromDefault(): void {}
+    makeApiClient(): unknown {
+      return {};
+    }
+    getCurrentContext(): string {
+      return 'mock';
+    }
+  },
+  PatchStrategy: { MergePatch: 'application/merge-patch+json' },
+  setHeaderOptions: () => ({}),
+}));
+
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { QueryFailedError, Repository } from 'typeorm';
+import { ShopCRClient } from '../k8s/shop-cr.client';
+import { Shop } from './entities/shop.entity';
+import { ShopsService } from './shops.service';
+
+describe('ShopsService (unit)', () => {
+  let service: ShopsService;
+  let repo: jest.Mocked<Repository<Shop>>;
+  let k8s: jest.Mocked<ShopCRClient>;
+
+  const ownerId = '00000000-0000-0000-0000-000000000001';
+  const otherId = '00000000-0000-0000-0000-000000000002';
+
+  const sampleInput = {
+    displayName: 'Demo',
+    host: 'demo.shophub.local',
+    availability: 'standard' as const,
+    databaseTier: 'standard' as const,
+    walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+    chainId: 11155111,
+  };
+
+  const buildShop = (over: Partial<Shop> = {}): Shop =>
+    ({
+      id: 'shop-id-1',
+      userId: ownerId,
+      k8sName: 'shop-deadbeef',
+      displayName: 'Demo',
+      host: 'demo.shophub.local',
+      availability: 'standard',
+      databaseTier: 'standard',
+      walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+      chainId: '11155111',
+      backendImage: null,
+      frontendImage: null,
+      lastKnownPhase: null,
+      lastKnownUrl: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      normalize: () => undefined,
+      ...over,
+    }) as Shop;
+
+  beforeEach(async () => {
+    const repoMock: Partial<jest.Mocked<Repository<Shop>>> = {
+      create: jest.fn().mockImplementation((data: Partial<Shop>) => buildShop(data)),
+      save: jest.fn().mockImplementation((shop: Shop) => Promise.resolve(shop)),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const k8sMock: Partial<jest.Mocked<ShopCRClient>> = {
+      isReady: jest.fn().mockReturnValue(true),
+      create: jest.fn(),
+      get: jest.fn(),
+      list: jest.fn(),
+      patchSpec: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ShopsService,
+        { provide: getRepositoryToken(Shop), useValue: repoMock },
+        { provide: ShopCRClient, useValue: k8sMock },
+      ],
+    }).compile();
+
+    service = moduleRef.get(ShopsService);
+    repo = moduleRef.get(getRepositoryToken(Shop));
+    k8s = moduleRef.get(ShopCRClient);
+  });
+
+  describe('createForUser', () => {
+    it('persists the shop and applies a Shop CR with the mapped spec', async () => {
+      await service.createForUser(ownerId, sampleInput);
+
+      expect(repo.save).toHaveBeenCalledTimes(1);
+      const saved = repo.save.mock.calls[0][0] as Shop;
+      expect(saved.userId).toBe(ownerId);
+      expect(saved.k8sName).toMatch(/^shop-[a-f0-9]{8}$/);
+
+      expect(k8s.create).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8s.create.mock.calls[0];
+      expect(name).toBe(saved.k8sName);
+      expect(spec).toMatchObject({
+        displayName: 'Demo',
+        host: 'demo.shophub.local',
+        availability: 'standard',
+        databaseTier: 'standard',
+        walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+        chainId: 11155111,
+      });
+    });
+
+    it('rolls back the DB row when the CR create fails', async () => {
+      k8s.create.mockRejectedValue(new Error('cluster unreachable'));
+
+      await expect(
+        service.createForUser(ownerId, sampleInput),
+      ).rejects.toThrow('cluster unreachable');
+
+      expect(repo.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('translates DB unique violations to ConflictException', async () => {
+      const err = new QueryFailedError('q', [], new Error('dup'));
+      (err as QueryFailedError & { code?: string }).code = '23505';
+      repo.save.mockRejectedValueOnce(err);
+
+      await expect(
+        service.createForUser(ownerId, sampleInput),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(k8s.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOneForUser', () => {
+    it('returns the shop when it belongs to the user', async () => {
+      const shop = buildShop();
+      repo.findOne.mockResolvedValue(shop);
+
+      const got = await service.findOneForUser(ownerId, shop.id);
+      expect(got).toBe(shop);
+    });
+
+    it("throws NotFoundException when the shop belongs to another user", async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.findOneForUser(otherId, 'shop-id-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateForUser', () => {
+    it('patches the CR with the merged spec', async () => {
+      const existing = buildShop();
+      repo.findOne.mockResolvedValue(existing);
+
+      await service.updateForUser(ownerId, existing.id, {
+        availability: 'high',
+        walletAddress: '0x1111111111111111111111111111111111111111',
+      });
+
+      expect(k8s.patchSpec).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8s.patchSpec.mock.calls[0];
+      expect(name).toBe(existing.k8sName);
+      expect(spec.availability).toBe('high');
+      expect(spec.walletAddress).toBe('0x1111111111111111111111111111111111111111');
+    });
+  });
+
+  describe('deleteForUser', () => {
+    it('deletes the CR before deleting the DB row', async () => {
+      const existing = buildShop();
+      repo.findOne.mockResolvedValue(existing);
+      const order: string[] = [];
+      k8s.delete.mockImplementation(async () => {
+        order.push('cr');
+      });
+      repo.delete.mockImplementation(async () => {
+        order.push('db');
+        return { affected: 1, raw: [] };
+      });
+
+      await service.deleteForUser(ownerId, existing.id);
+
+      expect(order).toEqual(['cr', 'db']);
+    });
+  });
+
+  describe('syncAllStatuses', () => {
+    it('copies phase and url from the CR to the DB', async () => {
+      const shop = buildShop({ lastKnownPhase: null, lastKnownUrl: null });
+      repo.find.mockResolvedValue([shop]);
+      k8s.get.mockResolvedValue({
+        apiVersion: 'shophub.io/v1alpha1',
+        kind: 'Shop',
+        metadata: { name: shop.k8sName, namespace: 'shophub-tenants' },
+        spec: {
+          displayName: shop.displayName,
+          host: shop.host,
+          availability: shop.availability,
+          databaseTier: shop.databaseTier,
+          walletAddress: shop.walletAddress,
+        },
+        status: { phase: 'Ready', url: 'https://demo.shophub.local' },
+      });
+
+      await service.syncAllStatuses();
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastKnownPhase: 'Ready',
+          lastKnownUrl: 'https://demo.shophub.local',
+        }),
+      );
+    });
+
+    it('does nothing when the K8s client is not ready', async () => {
+      k8s.isReady.mockReturnValue(false);
+      await service.syncAllStatuses();
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -1,0 +1,168 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { QueryFailedError, Repository } from 'typeorm';
+import { ShopCRClient } from '../k8s/shop-cr.client';
+import { ShopSpec } from '../k8s/shop-cr.types';
+import { Shop } from './entities/shop.entity';
+import { shopEntityToCRSpec } from './shops.mapper';
+
+const PG_UNIQUE_VIOLATION = '23505';
+
+export interface CreateShopInput {
+  displayName: string;
+  host: string;
+  availability: ShopSpec['availability'];
+  databaseTier: ShopSpec['databaseTier'];
+  walletAddress: string;
+  chainId?: number;
+  backendImage?: string;
+  frontendImage?: string;
+}
+
+export interface UpdateShopInput {
+  displayName?: string;
+  availability?: ShopSpec['availability'];
+  databaseTier?: ShopSpec['databaseTier'];
+  walletAddress?: string;
+  chainId?: number;
+  backendImage?: string | null;
+  frontendImage?: string | null;
+}
+
+@Injectable()
+export class ShopsService {
+  private readonly logger = new Logger(ShopsService.name);
+
+  constructor(
+    @InjectRepository(Shop)
+    private readonly shops: Repository<Shop>,
+    private readonly k8s: ShopCRClient,
+  ) {}
+
+  async createForUser(userId: string, input: CreateShopInput): Promise<Shop> {
+    const shop = this.shops.create({
+      userId,
+      k8sName: generateShopK8sName(),
+      displayName: input.displayName,
+      host: input.host,
+      availability: input.availability,
+      databaseTier: input.databaseTier,
+      walletAddress: input.walletAddress,
+      chainId: String(input.chainId ?? 11155111),
+      backendImage: input.backendImage ?? null,
+      frontendImage: input.frontendImage ?? null,
+    });
+
+    let saved: Shop;
+    try {
+      saved = await this.shops.save(shop);
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        throw new ConflictException('Host or shop name is already taken');
+      }
+      throw err;
+    }
+
+    try {
+      await this.k8s.create(saved.k8sName, shopEntityToCRSpec(saved));
+    } catch (err) {
+      this.logger.error(
+        `Failed to create Shop CR ${saved.k8sName}, rolling back DB row`,
+        err instanceof Error ? err.stack : String(err),
+      );
+      await this.shops.delete(saved.id);
+      throw err;
+    }
+    return saved;
+  }
+
+  findAllForUser(userId: string): Promise<Shop[]> {
+    return this.shops.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOneForUser(userId: string, id: string): Promise<Shop> {
+    const shop = await this.shops.findOne({ where: { id, userId } });
+    if (!shop) {
+      throw new NotFoundException('Shop not found');
+    }
+    return shop;
+  }
+
+  async updateForUser(
+    userId: string,
+    id: string,
+    input: UpdateShopInput,
+  ): Promise<Shop> {
+    const shop = await this.findOneForUser(userId, id);
+
+    if (input.displayName !== undefined) shop.displayName = input.displayName;
+    if (input.availability !== undefined) shop.availability = input.availability;
+    if (input.databaseTier !== undefined) shop.databaseTier = input.databaseTier;
+    if (input.walletAddress !== undefined) shop.walletAddress = input.walletAddress;
+    if (input.chainId !== undefined) shop.chainId = String(input.chainId);
+    if (input.backendImage !== undefined) shop.backendImage = input.backendImage;
+    if (input.frontendImage !== undefined) shop.frontendImage = input.frontendImage;
+
+    const saved = await this.shops.save(shop);
+    await this.k8s.patchSpec(saved.k8sName, shopEntityToCRSpec(saved));
+    return saved;
+  }
+
+  async deleteForUser(userId: string, id: string): Promise<void> {
+    const shop = await this.findOneForUser(userId, id);
+    await this.k8s.delete(shop.k8sName);
+    await this.shops.delete(shop.id);
+  }
+
+  /**
+   * Sweeps every Shop row and copies the latest phase + url from its CR
+   * status into the DB. Intended to be called from a scheduled job.
+   */
+  async syncAllStatuses(): Promise<void> {
+    if (!this.k8s.isReady()) {
+      return;
+    }
+    const shops = await this.shops.find();
+    for (const shop of shops) {
+      try {
+        const cr = await this.k8s.get(shop.k8sName);
+        if (!cr) {
+          continue;
+        }
+        const phase = cr.status?.phase ?? null;
+        const url = cr.status?.url ?? null;
+        if (phase !== shop.lastKnownPhase || url !== shop.lastKnownUrl) {
+          shop.lastKnownPhase = phase;
+          shop.lastKnownUrl = url;
+          await this.shops.save(shop);
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Status sync failed for shop ${shop.k8sName}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  private isUniqueViolation(err: unknown): boolean {
+    return (
+      err instanceof QueryFailedError &&
+      (err as QueryFailedError & { code?: string }).code === PG_UNIQUE_VIOLATION
+    );
+  }
+}
+
+function generateShopK8sName(): string {
+  return `shop-${randomBytes(4).toString('hex')}`;
+}

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,4 +1,23 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+// @kubernetes/client-node ships as ESM in v1.x; ts-jest's CJS transform
+// chokes on it. e2e tests boot the full AppModule which pulls in
+// ShopsModule -> ShopCRClient -> @kubernetes/client-node, so we stub it
+// at module-load time. No K8s calls happen in these tests.
+jest.mock('@kubernetes/client-node', () => ({
+  CustomObjectsApi: class {},
+  KubeConfig: class {
+    loadFromDefault(): void {}
+    makeApiClient(): unknown {
+      return {};
+    }
+    getCurrentContext(): string {
+      return 'mock';
+    }
+  },
+  PatchStrategy: { MergePatch: 'application/merge-patch+json' },
+  setHeaderOptions: () => ({}),
+}));
+
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {

--- a/backend/test/integration/shops.int-spec.ts
+++ b/backend/test/integration/shops.int-spec.ts
@@ -1,0 +1,229 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+jest.mock('@kubernetes/client-node', () => ({
+  CustomObjectsApi: class {},
+  KubeConfig: class {
+    loadFromDefault(): void {}
+    makeApiClient(): unknown {
+      return {};
+    }
+    getCurrentContext(): string {
+      return 'mock';
+    }
+  },
+  PatchStrategy: { MergePatch: 'application/merge-patch+json' },
+  setHeaderOptions: () => ({}),
+}));
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import request from 'supertest';
+import { AuthModule } from '../../src/auth/auth.module';
+import { validateEnv } from '../../src/config/env.validation';
+import { ShopCRClient } from '../../src/k8s/shop-cr.client';
+import { ShopsModule } from '../../src/shops/shops.module';
+import { UsersModule } from '../../src/users/users.module';
+
+describe('Shops (integration)', () => {
+  let container: StartedPostgreSqlContainer;
+  let app: INestApplication;
+  let token: string;
+
+  const k8sMock = {
+    isReady: jest.fn().mockReturnValue(true),
+    create: jest.fn().mockResolvedValue({}),
+    get: jest.fn().mockResolvedValue(null),
+    list: jest.fn().mockResolvedValue([]),
+    patchSpec: jest.fn().mockResolvedValue({}),
+    delete: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:16-alpine').start();
+
+    process.env.DATABASE_URL = `postgres://${container.getUsername()}:${container.getPassword()}@${container.getHost()}:${container.getMappedPort(5432)}/${container.getDatabase()}`;
+    process.env.JWT_SECRET = 'test-secret-with-at-least-32-characters!!';
+    process.env.JWT_EXPIRES_IN = '1h';
+    process.env.SIWE_DOMAIN = 'localhost:3000';
+    process.env.SIWE_ORIGIN = 'http://localhost:3000';
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          cache: false,
+          ignoreEnvFile: true,
+          validate: validateEnv,
+        }),
+        ScheduleModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          url: process.env.DATABASE_URL,
+          autoLoadEntities: true,
+          synchronize: true,
+        }),
+        UsersModule,
+        AuthModule,
+        ShopsModule,
+      ],
+    })
+      .overrideProvider(ShopCRClient)
+      .useValue(k8sMock)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    const register = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'owner@example.com', password: 'password123' });
+    token = register.body.accessToken;
+  }, 90000);
+
+  afterAll(async () => {
+    await app?.close();
+    await container?.stop();
+  });
+
+  beforeEach(() => {
+    k8sMock.create.mockClear();
+    k8sMock.patchSpec.mockClear();
+    k8sMock.delete.mockClear();
+  });
+
+  const validShop = {
+    displayName: 'Demo Store',
+    host: 'demo.shophub.local',
+    availability: 'standard',
+    databaseTier: 'standard',
+    walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+  };
+
+  describe('POST /shops', () => {
+    it('rejects unauthenticated requests', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/shops')
+        .send(validShop);
+      expect(res.status).toBe(401);
+    });
+
+    it('creates a Shop, persists it, and applies a CR', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/shops')
+        .set('Authorization', `Bearer ${token}`)
+        .send(validShop);
+      expect(res.status).toBe(201);
+      expect(res.body.id).toEqual(expect.any(String));
+      expect(res.body.k8sName).toMatch(/^shop-[a-f0-9]{8}$/);
+      expect(res.body.host).toBe(validShop.host);
+      expect(k8sMock.create).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8sMock.create.mock.calls[0];
+      expect(name).toBe(res.body.k8sName);
+      expect(spec.host).toBe(validShop.host);
+    });
+
+    it('rejects invalid wallet addresses', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/shops')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ ...validShop, host: 'bad.shophub.local', walletAddress: 'not-an-address' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /shops and /shops/:id', () => {
+    let id: string;
+
+    beforeAll(async () => {
+      const res = await request(app.getHttpServer())
+        .post('/shops')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ ...validShop, host: 'list-test.shophub.local' });
+      id = res.body.id;
+    });
+
+    it('lists only the calling users shops', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/shops')
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.find((s: { id: string }) => s.id === id)).toBeDefined();
+    });
+
+    it('returns the shop by id', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/shops/${id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(id);
+    });
+
+    it('does not leak shops belonging to another user', async () => {
+      const otherReg = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: 'intruder@example.com', password: 'password123' });
+      const otherToken = otherReg.body.accessToken;
+
+      const list = await request(app.getHttpServer())
+        .get('/shops')
+        .set('Authorization', `Bearer ${otherToken}`);
+      expect(list.body).toHaveLength(0);
+
+      const get = await request(app.getHttpServer())
+        .get(`/shops/${id}`)
+        .set('Authorization', `Bearer ${otherToken}`);
+      expect(get.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /shops/:id and DELETE', () => {
+    let id: string;
+
+    beforeAll(async () => {
+      const res = await request(app.getHttpServer())
+        .post('/shops')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ ...validShop, host: 'patch-test.shophub.local' });
+      id = res.body.id;
+    });
+
+    it('patches the shop and the CR', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/shops/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ availability: 'high' });
+      expect(res.status).toBe(200);
+      expect(res.body.availability).toBe('high');
+      expect(k8sMock.patchSpec).toHaveBeenCalledTimes(1);
+      const [, spec] = k8sMock.patchSpec.mock.calls[0];
+      expect(spec.availability).toBe('high');
+    });
+
+    it('deletes the CR before deleting the DB row', async () => {
+      const res = await request(app.getHttpServer())
+        .delete(`/shops/${id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(204);
+      expect(k8sMock.delete).toHaveBeenCalledTimes(1);
+
+      const get = await request(app.getHttpServer())
+        .get(`/shops/${id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(get.status).toBe(404);
+    });
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,19 +20,27 @@ export default function Home() {
         {isLoading ? (
           <p className="text-sm text-zinc-500">Loading session...</p>
         ) : user ? (
-          <div className="space-y-2">
+          <div className="space-y-3">
             <p className="text-sm text-zinc-700 dark:text-zinc-300">
               Signed in as{' '}
               <span className="font-medium">
                 {user.email ?? user.walletAddress}
               </span>
             </p>
-            <button
-              onClick={logout}
-              className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
-            >
-              Sign out
-            </button>
+            <div className="flex gap-3">
+              <Link
+                href="/shops"
+                className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+              >
+                My shops
+              </Link>
+              <button
+                onClick={logout}
+                className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+              >
+                Sign out
+              </button>
+            </div>
           </div>
         ) : (
           <div className="flex gap-3">

--- a/frontend/src/app/shops/[id]/page.tsx
+++ b/frontend/src/app/shops/[id]/page.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import {
+  AvailabilityTier,
+  DatabaseTier,
+  Shop,
+  phaseColorClass,
+} from '@/lib/shop-types';
+
+interface EditableFields {
+  displayName: string;
+  availability: AvailabilityTier;
+  databaseTier: DatabaseTier;
+  walletAddress: string;
+  chainId: number;
+}
+
+const editInputClass =
+  'w-full rounded border border-zinc-300 bg-white px-2 py-1 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100';
+
+export default function ShopDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [shop, setShop] = useState<Shop | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const id = params.id;
+
+  const fetchShop = useCallback(() => {
+    api
+      .getShop(id)
+      .then(setShop)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) {
+          setError('Shop not found');
+        } else if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to load shop');
+        }
+      });
+  }, [id]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    fetchShop();
+    const interval = setInterval(() => {
+      if (!editing) fetchShop();
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router, fetchShop, editing]);
+
+  const onDelete = async () => {
+    if (!shop) return;
+    if (!window.confirm(`Delete "${shop.displayName}"? This cannot be undone.`)) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await api.deleteShop(shop.id);
+      router.push('/shops');
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to delete shop');
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+  if (error && !shop) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+      </div>
+    );
+  }
+  if (!shop) {
+    return <div className="p-8 text-zinc-500">Loading shop...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-3xl px-8 py-12">
+        <div className="mb-2 text-sm text-zinc-500">
+          <button
+            type="button"
+            onClick={() => router.push('/shops')}
+            className="underline"
+          >
+            ← All shops
+          </button>
+        </div>
+
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+              {shop.displayName}
+            </h1>
+            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+              {shop.host}
+            </p>
+          </div>
+          <span
+            className={`rounded px-3 py-1 text-sm font-medium ${phaseColorClass(shop.lastKnownPhase)}`}
+          >
+            {shop.lastKnownPhase ?? 'Pending'}
+          </span>
+        </div>
+
+        {editing ? (
+          <EditPanel
+            shop={shop}
+            onCancel={() => setEditing(false)}
+            onSaved={(updated) => {
+              setShop(updated);
+              setEditing(false);
+            }}
+            onError={setError}
+            externalError={error}
+          />
+        ) : (
+          <>
+            <dl className="grid grid-cols-2 gap-4 rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <Field label="External URL">
+                {shop.lastKnownUrl ? (
+                  <a
+                    href={shop.lastKnownUrl}
+                    className="break-all text-blue-600 underline dark:text-blue-400"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {shop.lastKnownUrl}
+                  </a>
+                ) : (
+                  <span className="text-zinc-500">(not ready yet)</span>
+                )}
+              </Field>
+              <Field label="Availability">{shop.availability}</Field>
+              <Field label="Database tier">{shop.databaseTier}</Field>
+              <Field label="Wallet">
+                <span className="break-all font-mono text-xs">
+                  {shop.walletAddress}
+                </span>
+              </Field>
+              <Field label="Chain ID">{shop.chainId}</Field>
+              <Field label="Created">
+                {new Date(shop.createdAt).toLocaleString()}
+              </Field>
+              <Field label="K8s name">
+                <span className="font-mono text-xs">{shop.k8sName}</span>
+              </Field>
+            </dl>
+
+            {error && (
+              <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+                {error}
+              </p>
+            )}
+
+            <div className="mt-6 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  setEditing(true);
+                }}
+                className="rounded border border-zinc-300 px-4 py-2 text-sm hover:bg-black/[.04] dark:border-zinc-700 dark:hover:bg-white/[.04]"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={deleting}
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? 'Deleting...' : 'Delete shop'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditPanel({
+  shop,
+  onCancel,
+  onSaved,
+  onError,
+  externalError,
+}: {
+  shop: Shop;
+  onCancel: () => void;
+  onSaved: (updated: Shop) => void;
+  onError: (msg: string | null) => void;
+  externalError: string | null;
+}) {
+  const [draft, setDraft] = useState<EditableFields>({
+    displayName: shop.displayName,
+    availability: shop.availability,
+    databaseTier: shop.databaseTier,
+    walletAddress: shop.walletAddress,
+    chainId: Number(shop.chainId),
+  });
+  const [saving, setSaving] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    onError(null);
+    try {
+      const updated = await api.updateShop(shop.id, draft);
+      onSaved(updated);
+    } catch (err) {
+      onError(err instanceof ApiError ? err.message : 'Failed to save changes');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="External URL">
+          {shop.lastKnownUrl ? (
+            <a
+              href={shop.lastKnownUrl}
+              className="break-all text-blue-600 underline dark:text-blue-400"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {shop.lastKnownUrl}
+            </a>
+          ) : (
+            <span className="text-zinc-500">(not ready yet)</span>
+          )}
+        </Field>
+        <Field label="Display name">
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={draft.displayName}
+            onChange={(e) =>
+              setDraft({ ...draft, displayName: e.target.value })
+            }
+            className={editInputClass}
+          />
+        </Field>
+        <Field label="Availability">
+          <select
+            value={draft.availability}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                availability: e.target.value as AvailabilityTier,
+              })
+            }
+            className={editInputClass}
+          >
+            <option value="standard">standard (2 replicas)</option>
+            <option value="high">high (3 replicas)</option>
+          </select>
+        </Field>
+        <Field label="Database tier">
+          <select
+            value={draft.databaseTier}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                databaseTier: e.target.value as DatabaseTier,
+              })
+            }
+            className={editInputClass}
+          >
+            <option value="standard">standard (Postgres)</option>
+            <option value="light">light (Redis)</option>
+          </select>
+        </Field>
+        <Field label="Wallet">
+          <input
+            type="text"
+            required
+            pattern="^0x[a-fA-F0-9]{40}$"
+            value={draft.walletAddress}
+            onChange={(e) =>
+              setDraft({ ...draft, walletAddress: e.target.value })
+            }
+            className={`${editInputClass} font-mono`}
+          />
+        </Field>
+        <Field label="Chain ID">
+          <input
+            type="number"
+            min={1}
+            value={draft.chainId}
+            onChange={(e) =>
+              setDraft({ ...draft, chainId: Number(e.target.value) })
+            }
+            className={editInputClass}
+          />
+        </Field>
+        <Field label="Host (read-only)">
+          <span className="text-zinc-500">{shop.host}</span>
+        </Field>
+        <Field label="K8s name (read-only)">
+          <span className="font-mono text-xs text-zinc-500">{shop.k8sName}</span>
+        </Field>
+      </div>
+
+      {externalError && (
+        <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+          {externalError}
+        </p>
+      )}
+
+      <div className="mt-6 flex gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+        >
+          {saving ? 'Saving...' : 'Save changes'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-black dark:text-zinc-100">{children}</dd>
+    </div>
+  );
+}

--- a/frontend/src/app/shops/new/page.tsx
+++ b/frontend/src/app/shops/new/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import { AvailabilityTier, DatabaseTier } from '@/lib/shop-types';
+
+export default function NewShopPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+
+  const [displayName, setDisplayName] = useState('');
+  const [host, setHost] = useState('');
+  const [availability, setAvailability] = useState<AvailabilityTier>('standard');
+  const [databaseTier, setDatabaseTier] = useState<DatabaseTier>('standard');
+  const [walletAddress, setWalletAddress] = useState('');
+  const [chainId, setChainId] = useState(11155111);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/login');
+    }
+  }, [authLoading, user, router]);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const shop = await api.createShop({
+        displayName,
+        host,
+        availability,
+        databaseTier,
+        walletAddress,
+        chainId,
+      });
+      router.push(`/shops/${shop.id}`);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to create shop');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center bg-zinc-50 dark:bg-black">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-lg space-y-4 rounded-lg border border-black/[.08] bg-white p-8 dark:border-white/[.12] dark:bg-zinc-900"
+      >
+        <h1 className="text-2xl font-semibold text-black dark:text-zinc-50">
+          Create a shop
+        </h1>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Display name</span>
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="My Cool Shop"
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Host (DNS-1123)</span>
+          <input
+            type="text"
+            required
+            pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="my-shop.shophub.local"
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+          <span className="block text-xs text-zinc-500">
+            Lowercase, dots and hyphens only. Used as the Ingress hostname.
+          </span>
+        </label>
+
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <label className="block space-y-1">
+            <span className="text-zinc-700 dark:text-zinc-300">Availability</span>
+            <select
+              value={availability}
+              onChange={(e) => setAvailability(e.target.value as AvailabilityTier)}
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            >
+              <option value="standard">standard (2 replicas)</option>
+              <option value="high">high (3 replicas)</option>
+            </select>
+          </label>
+
+          <label className="block space-y-1">
+            <span className="text-zinc-700 dark:text-zinc-300">Database tier</span>
+            <select
+              value={databaseTier}
+              onChange={(e) => setDatabaseTier(e.target.value as DatabaseTier)}
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            >
+              <option value="standard">standard (Postgres / CNPG)</option>
+              <option value="light">light (Redis / REDB)</option>
+            </select>
+          </label>
+        </div>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Wallet address (EVM)</span>
+          <input
+            type="text"
+            required
+            pattern="^0x[a-fA-F0-9]{40}$"
+            value={walletAddress}
+            onChange={(e) => setWalletAddress(e.target.value)}
+            placeholder="0xabc..."
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Chain ID</span>
+          <input
+            type="number"
+            min={1}
+            value={chainId}
+            onChange={(e) => setChainId(Number(e.target.value))}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+          <span className="block text-xs text-zinc-500">
+            Default 11155111 (Sepolia testnet).
+          </span>
+        </label>
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex-1 rounded bg-foreground py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+          >
+            {submitting ? 'Creating...' : 'Create shop'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/shops')}
+            className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/shops/page.tsx
+++ b/frontend/src/app/shops/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import { Shop, phaseColorClass } from '@/lib/shop-types';
+
+export default function ShopsListPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [shops, setShops] = useState<Shop[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    const refresh = () => {
+      api
+        .listShops()
+        .then(setShops)
+        .catch((err) => {
+          if (err instanceof ApiError) setError(err.message);
+          else setError('Failed to load shops');
+        });
+    };
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router]);
+
+  if (authLoading || (!user && !error)) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-4xl px-8 py-12">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+            My shops
+          </h1>
+          <Link
+            href="/shops/new"
+            className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          >
+            + New shop
+          </Link>
+        </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        {shops === null ? (
+          <p className="text-sm text-zinc-500">Loading shops...</p>
+        ) : shops.length === 0 ? (
+          <div className="rounded border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-700">
+            <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+              You don&apos;t have any shops yet.
+            </p>
+            <Link
+              href="/shops/new"
+              className="inline-block rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+            >
+              Create your first shop
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {shops.map((shop) => (
+              <li
+                key={shop.id}
+                className="rounded border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <Link href={`/shops/${shop.id}`} className="block">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-lg font-medium text-black dark:text-zinc-50">
+                        {shop.displayName}
+                      </h2>
+                      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                        {shop.host}
+                      </p>
+                    </div>
+                    <span
+                      className={`rounded px-2 py-1 text-xs font-medium ${phaseColorClass(shop.lastKnownPhase)}`}
+                    >
+                      {shop.lastKnownPhase ?? 'Pending'}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex gap-3 text-xs text-zinc-500">
+                    <span>availability: {shop.availability}</span>
+                    <span>db: {shop.databaseTier}</span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,4 +1,5 @@
 import { authStorage, StoredUser } from './auth-storage';
+import { CreateShopRequest, Shop, UpdateShopRequest } from './shop-types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
 
@@ -74,5 +75,26 @@ export const api = {
   },
   me(): Promise<StoredUser> {
     return request<StoredUser>('/auth/me');
+  },
+  listShops(): Promise<Shop[]> {
+    return request<Shop[]>('/shops');
+  },
+  getShop(id: string): Promise<Shop> {
+    return request<Shop>(`/shops/${id}`);
+  },
+  createShop(payload: CreateShopRequest): Promise<Shop> {
+    return request<Shop>('/shops', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+  updateShop(id: string, payload: UpdateShopRequest): Promise<Shop> {
+    return request<Shop>(`/shops/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  },
+  deleteShop(id: string): Promise<void> {
+    return request<void>(`/shops/${id}`, { method: 'DELETE' });
   },
 };

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -24,14 +24,17 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<StoredUser | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  // Skip the initial loading flicker when there is no token to validate.
+  // Lazy initializer runs once on mount; localStorage is browser-only so
+  // we guard for SSR even though this component is rendered client-side.
+  const [isLoading, setIsLoading] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return authStorage.getToken() !== null;
+  });
 
   useEffect(() => {
     const token = authStorage.getToken();
-    if (!token) {
-      setIsLoading(false);
-      return;
-    }
+    if (!token) return;
     api
       .me()
       .then((fresh) => {

--- a/frontend/src/lib/shop-types.ts
+++ b/frontend/src/lib/shop-types.ts
@@ -1,0 +1,62 @@
+export type AvailabilityTier = 'standard' | 'high';
+export type DatabaseTier = 'standard' | 'light';
+export type ShopPhase =
+  | 'Pending'
+  | 'Provisioning'
+  | 'Ready'
+  | 'Failed'
+  | 'Terminating';
+
+export interface Shop {
+  id: string;
+  userId: string;
+  k8sName: string;
+  displayName: string;
+  host: string;
+  availability: AvailabilityTier;
+  databaseTier: DatabaseTier;
+  walletAddress: string;
+  chainId: string;
+  backendImage: string | null;
+  frontendImage: string | null;
+  lastKnownPhase: ShopPhase | null;
+  lastKnownUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateShopRequest {
+  displayName: string;
+  host: string;
+  availability: AvailabilityTier;
+  databaseTier: DatabaseTier;
+  walletAddress: string;
+  chainId?: number;
+  backendImage?: string;
+  frontendImage?: string;
+}
+
+export interface UpdateShopRequest {
+  displayName?: string;
+  availability?: AvailabilityTier;
+  databaseTier?: DatabaseTier;
+  walletAddress?: string;
+  chainId?: number;
+  backendImage?: string | null;
+  frontendImage?: string | null;
+}
+
+export function phaseColorClass(phase: ShopPhase | null): string {
+  switch (phase) {
+    case 'Ready':
+      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+    case 'Provisioning':
+      return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100';
+    case 'Failed':
+      return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+    case 'Terminating':
+      return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100';
+    default:
+      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200';
+  }
+}


### PR DESCRIPTION
## Summary
Implements shophub#11 - the bridge between the ShopHub panel and the shop-operator. A logged-in user creates a Shop in the panel; the backend persists a row and applies a Shop CR in shophub-tenants. The operator (shop-operator#7) reconciles the CR into Deployments, Services, and Ingress. Status flows back into the panel via a poller.

Branch is based on feat/auth (PR #N, not yet merged) since the new endpoints all depend on the JwtAuthGuard and User entity from that PR.

## Architectural choices
- Single shop-operator namespace `shophub-tenants` for all tenants; tenant isolation is by label, not namespace. Simpler RBAC.
- K8s `metadata.name` is auto-generated (`shop-<8 hex>`) and never  shown to users. `displayName` and `host` are the user-facing identifiers; `host` and `k8sName` are immutable.
- Status sync is a 30s polling sweep. Informer/watch can replace it later if responsiveness becomes a problem.
- Create flow is two-phase: persist DB first, then apply CR. If the CR apply fails the DB row is rolled back so the panel never shows a shop that does not exist in the cluster.
- Delete flow is the reverse: delete CR first (so the operator can observe DeletionTimestamp and run its finalizer), then delete the DB row.

## Test coverage
- 19 backend unit tests (auth + ShopsService + nonce store)
- 2 e2e tests
- 19 integration tests via Testcontainers Postgres (auth + shops)
- @kubernetes/client-node is stubbed at jest.mock since the package is ESM-only and ts-jest's CJS transform cannot load it; we never exercise the real client in tests (ShopCRClient is replaced via DI).

## Manual verification
- Logged in via email/password, created a shop through the form
- Shop CR appeared in the kind cluster with the correct spec
- Operator reconciled Deployments, Services, Ingress, ConfigMap, Secret with correct names, replicas, labels, and owner references
- Phase progressed from Pending to Provisioning (Deployments stay at 0/2 because image registry contents do not exist yet, which is expected and unrelated to this PR)
- Edit panel patched availability and the operator picked it up
- Deleting the shop in the panel removed the CR and all owned resources

## Test plan
- [x] make test (unit + e2e + integration) all green
- [x] frontend npm run build clean
- [x] frontend npm run lint clean
- [x] manual E2E on kind cluster shophub-dev

Closes #11