### PR TITLE
Feat/discord channels and wallets

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { DatabaseModule } from './database/database.module';
 import { DiscordChannelsModule } from './discord-channels/discord-channels.module';
 import { ShopsModule } from './shops/shops.module';
 import { UsersModule } from './users/users.module';
+import { WalletsModule } from './wallets/wallets.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { UsersModule } from './users/users.module';
     AuthModule,
     ShopsModule,
     DiscordChannelsModule,
+    WalletsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { validateEnv } from './config/env.validation';
 import { DatabaseModule } from './database/database.module';
+import { DiscordChannelsModule } from './discord-channels/discord-channels.module';
 import { ShopsModule } from './shops/shops.module';
 import { UsersModule } from './users/users.module';
 
@@ -22,6 +23,7 @@ import { UsersModule } from './users/users.module';
     UsersModule,
     AuthModule,
     ShopsModule,
+    DiscordChannelsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/database/migrations/1716800000000-AddDiscordChannelsTable.ts
+++ b/backend/src/database/migrations/1716800000000-AddDiscordChannelsTable.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDiscordChannelsTable1716800000000 implements MigrationInterface {
+  name = 'AddDiscordChannelsTable1716800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "discord_channels" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "shop_id" uuid REFERENCES "shops"("id") ON DELETE SET NULL,
+        "k8s_name" varchar(63) NOT NULL,
+        "secret_name" varchar(63) NOT NULL,
+        "channel_name" varchar(80) NOT NULL,
+        "min_severity" varchar(16) NOT NULL,
+        "last_known_phase" varchar(16),
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "chk_discord_channels_min_severity"
+          CHECK ("min_severity" IN ('info', 'warning', 'critical'))
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uniq_discord_channels_k8s_name" ON "discord_channels" ("k8s_name")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uniq_discord_channels_secret_name" ON "discord_channels" ("secret_name")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_discord_channels_user_id" ON "discord_channels" ("user_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_discord_channels_shop_id" ON "discord_channels" ("shop_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_discord_channels_shop_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_discord_channels_user_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "uniq_discord_channels_secret_name"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "uniq_discord_channels_k8s_name"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "discord_channels"`);
+  }
+}

--- a/backend/src/database/migrations/1716800000001-AddWalletsTable.ts
+++ b/backend/src/database/migrations/1716800000001-AddWalletsTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWalletsTable1716800000001 implements MigrationInterface {
+  name = 'AddWalletsTable1716800000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "wallets" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "k8s_name" varchar(63) NOT NULL,
+        "display_name" varchar(80) NOT NULL,
+        "address" varchar(42) NOT NULL,
+        "chain_id" bigint NOT NULL DEFAULT 11155111,
+        "purpose" varchar(16) NOT NULL,
+        "last_known_phase" varchar(16),
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "chk_wallets_purpose"
+          CHECK ("purpose" IN ('payments', 'payout'))
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uniq_wallets_k8s_name" ON "wallets" ("k8s_name")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_wallets_user_id" ON "wallets" ("user_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_wallets_address" ON "wallets" ("address")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_wallets_address"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_wallets_user_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "uniq_wallets_k8s_name"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "wallets"`);
+  }
+}

--- a/backend/src/discord-channels/discord-channels-status.poller.ts
+++ b/backend/src/discord-channels/discord-channels-status.poller.ts
@@ -1,0 +1,21 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DiscordChannelsService } from './discord-channels.service';
+
+@Injectable()
+export class DiscordChannelsStatusPoller {
+  private readonly logger = new Logger(DiscordChannelsStatusPoller.name);
+
+  constructor(private readonly channels: DiscordChannelsService) {}
+
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async sweep(): Promise<void> {
+    try {
+      await this.channels.syncAllStatuses();
+    } catch (err) {
+      this.logger.warn(
+        `Status sweep failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/backend/src/discord-channels/discord-channels.controller.ts
+++ b/backend/src/discord-channels/discord-channels.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { User } from '../users/entities/user.entity';
+import { CreateDiscordChannelDto } from './dto/create-discord-channel.dto';
+import { UpdateDiscordChannelDto } from './dto/update-discord-channel.dto';
+import { DiscordChannel } from './entities/discord-channel.entity';
+import { DiscordChannelsService } from './discord-channels.service';
+
+@Controller('discord-channels')
+@UseGuards(JwtAuthGuard)
+export class DiscordChannelsController {
+  constructor(private readonly channels: DiscordChannelsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(
+    @CurrentUser() user: User,
+    @Body() dto: CreateDiscordChannelDto,
+  ): Promise<DiscordChannel> {
+    return this.channels.createForUser(user.id, dto);
+  }
+
+  @Get()
+  list(@CurrentUser() user: User): Promise<DiscordChannel[]> {
+    return this.channels.findAllForUser(user.id);
+  }
+
+  @Get(':id')
+  get(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<DiscordChannel> {
+    return this.channels.findOneForUser(user.id, id);
+  }
+
+  @Patch(':id')
+  update(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateDiscordChannelDto,
+  ): Promise<DiscordChannel> {
+    return this.channels.updateForUser(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.channels.deleteForUser(user.id, id);
+  }
+}

--- a/backend/src/discord-channels/discord-channels.mapper.ts
+++ b/backend/src/discord-channels/discord-channels.mapper.ts
@@ -1,0 +1,21 @@
+import { DiscordChannelSpec } from '../k8s/discord-channel-cr.types';
+import { DiscordChannel } from './entities/discord-channel.entity';
+
+/**
+ * Translates a DiscordChannel database row plus the (optional) k8s name of
+ * the linked Shop into the spec the operator expects.
+ */
+export function discordChannelEntityToCRSpec(
+  channel: DiscordChannel,
+  shopK8sName: string | null,
+): DiscordChannelSpec {
+  const spec: DiscordChannelSpec = {
+    channelName: channel.channelName,
+    webhookSecretRef: { name: channel.secretName, key: 'url' },
+    minSeverity: channel.minSeverity,
+  };
+  if (shopK8sName) {
+    spec.shopRef = shopK8sName;
+  }
+  return spec;
+}

--- a/backend/src/discord-channels/discord-channels.module.ts
+++ b/backend/src/discord-channels/discord-channels.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { K8sModule } from '../k8s/k8s.module';
+import { Shop } from '../shops/entities/shop.entity';
+import { UsersModule } from '../users/users.module';
+import { DiscordChannel } from './entities/discord-channel.entity';
+import { DiscordChannelsController } from './discord-channels.controller';
+import { DiscordChannelsService } from './discord-channels.service';
+import { DiscordChannelsStatusPoller } from './discord-channels-status.poller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([DiscordChannel, Shop]),
+    AuthModule,
+    K8sModule,
+    UsersModule,
+  ],
+  controllers: [DiscordChannelsController],
+  providers: [DiscordChannelsService, DiscordChannelsStatusPoller],
+  exports: [DiscordChannelsService],
+})
+export class DiscordChannelsModule {}

--- a/backend/src/discord-channels/discord-channels.service.spec.ts
+++ b/backend/src/discord-channels/discord-channels.service.spec.ts
@@ -1,0 +1,276 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+// @kubernetes/client-node ships as ESM in v1.x; ts-jest's CJS transform
+// chokes on it. We never call the real client in unit tests (the CR client
+// and Secrets client are replaced via DI), so an empty mock at module load
+// time is enough.
+jest.mock('@kubernetes/client-node', () => ({
+  CustomObjectsApi: class {},
+  CoreV1Api: class {},
+  KubeConfig: class {
+    loadFromDefault(): void {}
+    makeApiClient(): unknown {
+      return {};
+    }
+    getCurrentContext(): string {
+      return 'mock';
+    }
+  },
+  PatchStrategy: { MergePatch: 'application/merge-patch+json' },
+  setHeaderOptions: () => ({}),
+}));
+
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { Repository } from 'typeorm';
+import { DiscordChannelCRClient } from '../k8s/discord-channel-cr.client';
+import { SecretsClient } from '../k8s/secrets.client';
+import { Shop } from '../shops/entities/shop.entity';
+import { DiscordChannel } from './entities/discord-channel.entity';
+import { DiscordChannelsService } from './discord-channels.service';
+
+describe('DiscordChannelsService (unit)', () => {
+  let service: DiscordChannelsService;
+  let channelRepo: jest.Mocked<Repository<DiscordChannel>>;
+  let shopRepo: jest.Mocked<Repository<Shop>>;
+  let k8s: jest.Mocked<DiscordChannelCRClient>;
+  let secrets: jest.Mocked<SecretsClient>;
+
+  const ownerId = '00000000-0000-0000-0000-000000000001';
+  const otherId = '00000000-0000-0000-0000-000000000002';
+  const shopId = '11111111-1111-1111-1111-111111111111';
+
+  const sampleInput = {
+    channelName: 'alerts',
+    webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+  };
+
+  const buildChannel = (over: Partial<DiscordChannel> = {}): DiscordChannel => ({
+    id: 'channel-id-1',
+    userId: ownerId,
+    shopId: null,
+    k8sName: 'dch-deadbeef',
+    secretName: 'dch-secret-deadbeef',
+    channelName: 'alerts',
+    minSeverity: 'warning',
+    lastKnownPhase: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  });
+
+  const buildShop = (over: Partial<Shop> = {}): Shop => ({
+    id: shopId,
+    userId: ownerId,
+    k8sName: 'shop-deadbeef',
+    displayName: 'Demo',
+    host: 'demo.shophub.local',
+    availability: 'standard',
+    databaseTier: 'standard',
+    walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+    chainId: '11155111',
+    backendImage: null,
+    frontendImage: null,
+    lastKnownPhase: null,
+    lastKnownUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    normalize: () => undefined,
+    ...over,
+  });
+
+  beforeEach(async () => {
+    const channelRepoMock: Partial<jest.Mocked<Repository<DiscordChannel>>> = {
+      create: jest
+        .fn()
+        .mockImplementation((data: Partial<DiscordChannel>) => buildChannel(data)),
+      save: jest
+        .fn()
+        .mockImplementation((channel: DiscordChannel) => Promise.resolve(channel)),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const shopRepoMock: Partial<jest.Mocked<Repository<Shop>>> = {
+      findOne: jest.fn(),
+    };
+    const k8sMock: Partial<jest.Mocked<DiscordChannelCRClient>> = {
+      isReady: jest.fn().mockReturnValue(true),
+      create: jest.fn(),
+      get: jest.fn(),
+      list: jest.fn(),
+      patchSpec: jest.fn(),
+      delete: jest.fn(),
+    };
+    const secretsMock: Partial<jest.Mocked<SecretsClient>> = {
+      isReady: jest.fn().mockReturnValue(true),
+      create: jest.fn(),
+      patchStringData: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        DiscordChannelsService,
+        { provide: getRepositoryToken(DiscordChannel), useValue: channelRepoMock },
+        { provide: getRepositoryToken(Shop), useValue: shopRepoMock },
+        { provide: DiscordChannelCRClient, useValue: k8sMock },
+        { provide: SecretsClient, useValue: secretsMock },
+      ],
+    }).compile();
+
+    service = moduleRef.get(DiscordChannelsService);
+    channelRepo = moduleRef.get(getRepositoryToken(DiscordChannel));
+    shopRepo = moduleRef.get(getRepositoryToken(Shop));
+    k8s = moduleRef.get(DiscordChannelCRClient);
+    secrets = moduleRef.get(SecretsClient);
+  });
+
+  describe('createForUser', () => {
+    it('writes the webhook URL to a Kubernetes Secret, then creates the CR', async () => {
+      await service.createForUser(ownerId, sampleInput);
+
+      expect(channelRepo.save).toHaveBeenCalledTimes(1);
+      const saved = channelRepo.save.mock.calls[0][0] as DiscordChannel;
+      expect(saved.k8sName).toMatch(/^dch-[a-f0-9]{8}$/);
+      expect(saved.secretName).toMatch(/^dch-secret-[a-f0-9]{8}$/);
+
+      expect(secrets.create).toHaveBeenCalledWith(saved.secretName, {
+        url: sampleInput.webhookUrl,
+      });
+      expect(k8s.create).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8s.create.mock.calls[0];
+      expect(name).toBe(saved.k8sName);
+      expect(spec.webhookSecretRef).toEqual({
+        name: saved.secretName,
+        key: 'url',
+      });
+      expect(spec.shopRef).toBeUndefined();
+    });
+
+    it('attaches the shop k8sName as shopRef when shopId is provided', async () => {
+      shopRepo.findOne.mockResolvedValue(buildShop());
+
+      await service.createForUser(ownerId, { ...sampleInput, shopId });
+
+      const [, spec] = k8s.create.mock.calls[0];
+      expect(spec.shopRef).toBe('shop-deadbeef');
+    });
+
+    it('rejects shopId that belongs to another user', async () => {
+      shopRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.createForUser(otherId, { ...sampleInput, shopId }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(secrets.create).not.toHaveBeenCalled();
+      expect(k8s.create).not.toHaveBeenCalled();
+    });
+
+    it('unwinds the Secret and DB row when the CR create fails', async () => {
+      k8s.create.mockRejectedValue(new Error('cluster unreachable'));
+
+      await expect(
+        service.createForUser(ownerId, sampleInput),
+      ).rejects.toThrow('cluster unreachable');
+
+      expect(secrets.delete).toHaveBeenCalledTimes(1);
+      expect(channelRepo.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the DB row when Secret create fails', async () => {
+      secrets.create.mockRejectedValue(new ConflictException('boom'));
+
+      await expect(
+        service.createForUser(ownerId, sampleInput),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(k8s.create).not.toHaveBeenCalled();
+      expect(channelRepo.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOneForUser', () => {
+    it('throws NotFoundException for someone else\'s channel', async () => {
+      channelRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.findOneForUser(otherId, 'channel-id-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateForUser', () => {
+    it('rotates the Secret when a new webhookUrl is supplied', async () => {
+      channelRepo.findOne.mockResolvedValue(buildChannel());
+
+      await service.updateForUser(ownerId, 'channel-id-1', {
+        webhookUrl: 'https://discord.com/api/webhooks/999/rotated',
+      });
+
+      expect(secrets.patchStringData).toHaveBeenCalledWith('dch-secret-deadbeef', {
+        url: 'https://discord.com/api/webhooks/999/rotated',
+      });
+      expect(k8s.patchSpec).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears shopRef when shopId is set to null', async () => {
+      channelRepo.findOne.mockResolvedValue(buildChannel({ shopId }));
+
+      await service.updateForUser(ownerId, 'channel-id-1', { shopId: null });
+
+      const [, spec] = k8s.patchSpec.mock.calls[0];
+      expect(spec.shopRef).toBeUndefined();
+    });
+  });
+
+  describe('deleteForUser', () => {
+    it('removes CR, Secret, then DB row in that order', async () => {
+      channelRepo.findOne.mockResolvedValue(buildChannel());
+      const order: string[] = [];
+      k8s.delete.mockImplementation(async () => {
+        order.push('cr');
+      });
+      secrets.delete.mockImplementation(async () => {
+        order.push('secret');
+      });
+      channelRepo.delete.mockImplementation(async () => {
+        order.push('db');
+        return { affected: 1, raw: [] };
+      });
+
+      await service.deleteForUser(ownerId, 'channel-id-1');
+
+      expect(order).toEqual(['cr', 'secret', 'db']);
+    });
+  });
+
+  describe('syncAllStatuses', () => {
+    it('copies phase from the CR to the DB', async () => {
+      const channel = buildChannel();
+      channelRepo.find.mockResolvedValue([channel]);
+      k8s.get.mockResolvedValue({
+        apiVersion: 'shophub.io/v1alpha1',
+        kind: 'DiscordChannel',
+        metadata: { name: channel.k8sName, namespace: 'shophub-tenants' },
+        spec: {
+          channelName: channel.channelName,
+          webhookSecretRef: { name: channel.secretName, key: 'url' },
+          minSeverity: channel.minSeverity,
+        },
+        status: { phase: 'Ready' },
+      });
+
+      await service.syncAllStatuses();
+
+      expect(channelRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ lastKnownPhase: 'Ready' }),
+      );
+    });
+
+    it('does nothing when the K8s client is not ready', async () => {
+      k8s.isReady.mockReturnValue(false);
+      await service.syncAllStatuses();
+      expect(channelRepo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/discord-channels/discord-channels.service.ts
+++ b/backend/src/discord-channels/discord-channels.service.ts
@@ -1,0 +1,227 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { QueryFailedError, Repository } from 'typeorm';
+import { DiscordChannelCRClient } from '../k8s/discord-channel-cr.client';
+import { SecretsClient } from '../k8s/secrets.client';
+import { Shop } from '../shops/entities/shop.entity';
+import { DiscordChannel } from './entities/discord-channel.entity';
+import { discordChannelEntityToCRSpec } from './discord-channels.mapper';
+
+const PG_UNIQUE_VIOLATION = '23505';
+const DEFAULT_MIN_SEVERITY = 'warning';
+
+export interface CreateDiscordChannelInput {
+  channelName: string;
+  webhookUrl: string;
+  shopId?: string;
+  minSeverity?: 'info' | 'warning' | 'critical';
+}
+
+export interface UpdateDiscordChannelInput {
+  channelName?: string;
+  webhookUrl?: string;
+  shopId?: string | null;
+  minSeverity?: 'info' | 'warning' | 'critical';
+}
+
+@Injectable()
+export class DiscordChannelsService {
+  private readonly logger = new Logger(DiscordChannelsService.name);
+
+  constructor(
+    @InjectRepository(DiscordChannel)
+    private readonly channels: Repository<DiscordChannel>,
+    @InjectRepository(Shop)
+    private readonly shops: Repository<Shop>,
+    private readonly k8s: DiscordChannelCRClient,
+    private readonly secrets: SecretsClient,
+  ) {}
+
+  async createForUser(
+    userId: string,
+    input: CreateDiscordChannelInput,
+  ): Promise<DiscordChannel> {
+    const shopK8sName = await this.resolveShopK8sName(userId, input.shopId);
+
+    const channel = this.channels.create({
+      userId,
+      shopId: input.shopId ?? null,
+      k8sName: generateChannelK8sName(),
+      secretName: generateSecretName(),
+      channelName: input.channelName,
+      minSeverity: input.minSeverity ?? DEFAULT_MIN_SEVERITY,
+    });
+
+    let saved: DiscordChannel;
+    try {
+      saved = await this.channels.save(channel);
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        throw new ConflictException('Channel name collision; please retry');
+      }
+      throw err;
+    }
+
+    // Order matters: Secret first so the CR has something to point at, then
+    // the CR. If either step fails we unwind in reverse and drop the DB row.
+    try {
+      await this.secrets.create(saved.secretName, { url: input.webhookUrl });
+    } catch (err) {
+      await this.channels.delete(saved.id);
+      throw err;
+    }
+
+    try {
+      await this.k8s.create(
+        saved.k8sName,
+        discordChannelEntityToCRSpec(saved, shopK8sName),
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to create DiscordChannel CR ${saved.k8sName}, unwinding Secret and DB row`,
+        err instanceof Error ? err.stack : String(err),
+      );
+      await this.safeDeleteSecret(saved.secretName);
+      await this.channels.delete(saved.id);
+      throw err;
+    }
+    return saved;
+  }
+
+  findAllForUser(userId: string): Promise<DiscordChannel[]> {
+    return this.channels.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOneForUser(userId: string, id: string): Promise<DiscordChannel> {
+    const channel = await this.channels.findOne({ where: { id, userId } });
+    if (!channel) {
+      throw new NotFoundException('Discord channel not found');
+    }
+    return channel;
+  }
+
+  async updateForUser(
+    userId: string,
+    id: string,
+    input: UpdateDiscordChannelInput,
+  ): Promise<DiscordChannel> {
+    const channel = await this.findOneForUser(userId, id);
+
+    if (input.shopId !== undefined) {
+      const newShopId = input.shopId;
+      if (newShopId === null) {
+        channel.shopId = null;
+      } else {
+        // resolveShopK8sName validates ownership; we accept its check as the
+        // authoritative answer and copy the id over.
+        await this.resolveShopK8sName(userId, newShopId);
+        channel.shopId = newShopId;
+      }
+    }
+    if (input.channelName !== undefined) channel.channelName = input.channelName;
+    if (input.minSeverity !== undefined) channel.minSeverity = input.minSeverity;
+
+    const saved = await this.channels.save(channel);
+
+    if (input.webhookUrl !== undefined) {
+      await this.secrets.patchStringData(saved.secretName, {
+        url: input.webhookUrl,
+      });
+    }
+
+    const shopK8sName = await this.resolveShopK8sName(
+      userId,
+      saved.shopId ?? undefined,
+    );
+    await this.k8s.patchSpec(
+      saved.k8sName,
+      discordChannelEntityToCRSpec(saved, shopK8sName),
+    );
+    return saved;
+  }
+
+  async deleteForUser(userId: string, id: string): Promise<void> {
+    const channel = await this.findOneForUser(userId, id);
+    await this.k8s.delete(channel.k8sName);
+    await this.safeDeleteSecret(channel.secretName);
+    await this.channels.delete(channel.id);
+  }
+
+  /**
+   * Sweeps every DiscordChannel row and copies the latest phase from its CR
+   * status into the DB. Intended to be called from a scheduled job.
+   */
+  async syncAllStatuses(): Promise<void> {
+    if (!this.k8s.isReady()) {
+      return;
+    }
+    const channels = await this.channels.find();
+    for (const channel of channels) {
+      try {
+        const cr = await this.k8s.get(channel.k8sName);
+        if (!cr) {
+          continue;
+        }
+        const phase = cr.status?.phase ?? null;
+        if (phase !== channel.lastKnownPhase) {
+          channel.lastKnownPhase = phase;
+          await this.channels.save(channel);
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Status sync failed for channel ${channel.k8sName}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  private async resolveShopK8sName(
+    userId: string,
+    shopId: string | undefined,
+  ): Promise<string | null> {
+    if (!shopId) return null;
+    const shop = await this.shops.findOne({ where: { id: shopId, userId } });
+    if (!shop) {
+      throw new NotFoundException('Shop not found for this user');
+    }
+    return shop.k8sName;
+  }
+
+  private async safeDeleteSecret(name: string): Promise<void> {
+    try {
+      await this.secrets.delete(name);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to delete Secret ${name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  private isUniqueViolation(err: unknown): boolean {
+    return (
+      err instanceof QueryFailedError &&
+      (err as QueryFailedError & { code?: string }).code === PG_UNIQUE_VIOLATION
+    );
+  }
+}
+
+function generateChannelK8sName(): string {
+  return `dch-${randomBytes(4).toString('hex')}`;
+}
+
+function generateSecretName(): string {
+  return `dch-secret-${randomBytes(4).toString('hex')}`;
+}

--- a/backend/src/discord-channels/dto/create-discord-channel.dto.ts
+++ b/backend/src/discord-channels/dto/create-discord-channel.dto.ts
@@ -1,0 +1,36 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class CreateDiscordChannelDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  channelName!: string;
+
+  /**
+   * Discord webhook URL. Never persisted to the platform DB - the service
+   * writes it to a Kubernetes Secret and stores only the Secret name.
+   */
+  @IsUrl({ require_protocol: true, protocols: ['https'] })
+  @MaxLength(512)
+  webhookUrl!: string;
+
+  /**
+   * Optional. When set, alerts are scoped to this Shop. The Shop must belong
+   * to the authenticated user.
+   */
+  @IsOptional()
+  @IsUUID()
+  shopId?: string;
+
+  @IsOptional()
+  @IsEnum(['info', 'warning', 'critical'] as const)
+  minSeverity?: 'info' | 'warning' | 'critical';
+}

--- a/backend/src/discord-channels/dto/update-discord-channel.dto.ts
+++ b/backend/src/discord-channels/dto/update-discord-channel.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  MaxLength,
+  MinLength,
+  ValidateIf,
+} from 'class-validator';
+
+// k8sName and secretName are immutable after creation - they identify
+// cluster objects that the operator already references.
+export class UpdateDiscordChannelDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  channelName?: string;
+
+  /**
+   * Optional new webhook URL. When supplied, the platform rotates the
+   * underlying Kubernetes Secret. Omitting it leaves the existing webhook in
+   * place.
+   */
+  @IsOptional()
+  @IsUrl({ require_protocol: true, protocols: ['https'] })
+  @MaxLength(512)
+  webhookUrl?: string;
+
+  /**
+   * Null clears the shop binding (channel becomes namespace-wide). Undefined
+   * leaves it unchanged.
+   */
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsUUID()
+  shopId?: string | null;
+
+  @IsOptional()
+  @IsEnum(['info', 'warning', 'critical'] as const)
+  minSeverity?: 'info' | 'warning' | 'critical';
+}

--- a/backend/src/discord-channels/entities/discord-channel.entity.ts
+++ b/backend/src/discord-channels/entities/discord-channel.entity.ts
@@ -1,0 +1,68 @@
+import {
+  Check,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type {
+  DiscordChannelPhase,
+  DiscordSeverity,
+} from '../../k8s/discord-channel-cr.types';
+
+@Entity({ name: 'discord_channels' })
+@Check(
+  'chk_discord_channels_min_severity',
+  `"min_severity" IN ('info', 'warning', 'critical')`,
+)
+@Index('uniq_discord_channels_k8s_name', ['k8sName'], { unique: true })
+@Index('uniq_discord_channels_secret_name', ['secretName'], { unique: true })
+@Index('idx_discord_channels_user_id', ['userId'])
+@Index('idx_discord_channels_shop_id', ['shopId'])
+export class DiscordChannel {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  /**
+   * Nullable. When set, the channel is scoped to a single Shop owned by the
+   * same user. Foreign key to shops(id) with ON DELETE SET NULL so deleting
+   * a Shop does not orphan the DiscordChannel; the channel reverts to an
+   * all-shops-in-namespace receiver.
+   */
+  @Column({ name: 'shop_id', type: 'uuid', nullable: true })
+  shopId!: string | null;
+
+  /**
+   * Auto-generated DNS-1123 label used as the DiscordChannel CR's metadata.name.
+   * Immutable after creation; users never see it directly.
+   */
+  @Column({ name: 'k8s_name', type: 'varchar', length: 63 })
+  k8sName!: string;
+
+  /**
+   * Name of the Kubernetes Secret holding the webhook URL under key `url`.
+   * Lives in the same tenant namespace as the CR.
+   */
+  @Column({ name: 'secret_name', type: 'varchar', length: 63 })
+  secretName!: string;
+
+  @Column({ name: 'channel_name', type: 'varchar', length: 80 })
+  channelName!: string;
+
+  @Column({ name: 'min_severity', type: 'varchar', length: 16 })
+  minSeverity!: DiscordSeverity;
+
+  @Column({ name: 'last_known_phase', type: 'varchar', length: 16, nullable: true })
+  lastKnownPhase!: DiscordChannelPhase | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/backend/src/k8s/discord-channel-cr.client.ts
+++ b/backend/src/k8s/discord-channel-cr.client.ts
@@ -5,32 +5,31 @@ import {
   setHeaderOptions,
 } from '@kubernetes/client-node';
 import {
+  ConflictException,
   Injectable,
   Logger,
   NotFoundException,
   OnModuleInit,
-  ConflictException,
 } from '@nestjs/common';
 import {
+  DISCORD_CHANNEL_CR_PLURAL,
   SHOP_CR_GROUP,
   SHOP_CR_NAMESPACE,
-  SHOP_CR_PLURAL,
   SHOP_CR_VERSION,
 } from './k8s.constants';
-import { ShopCR, ShopSpec } from './shop-cr.types';
+import {
+  DiscordChannelCR,
+  DiscordChannelSpec,
+} from './discord-channel-cr.types';
 
 /**
- * Wraps @kubernetes/client-node CustomObjectsApi for the Shop CRD.
- *
- * Connection strategy mirrors the official client default: try in-cluster
- * (mounted ServiceAccount token) first, fall back to ~/.kube/config for
- * local development. If neither is available the module still boots so
- * that unrelated requests (auth, health) keep working - K8s calls then
- * fail at request time with a descriptive error.
+ * Wraps @kubernetes/client-node CustomObjectsApi for the DiscordChannel CRD.
+ * Mirrors the connection strategy of ShopCRClient: in-cluster first, fall
+ * back to ~/.kube/config for local development.
  */
 @Injectable()
-export class ShopCRClient implements OnModuleInit {
-  private readonly logger = new Logger(ShopCRClient.name);
+export class DiscordChannelCRClient implements OnModuleInit {
+  private readonly logger = new Logger(DiscordChannelCRClient.name);
   private api?: CustomObjectsApi;
   private connectionError?: Error;
 
@@ -46,7 +45,7 @@ export class ShopCRClient implements OnModuleInit {
         err instanceof Error ? err : new Error(String(err));
       this.logger.warn(
         `Kubernetes client could not initialize: ${this.connectionError.message}. ` +
-          'Shop CR operations will fail until kubeconfig or in-cluster credentials are available.',
+          'DiscordChannel CR operations will fail until kubeconfig or in-cluster credentials are available.',
       );
     }
   }
@@ -55,11 +54,14 @@ export class ShopCRClient implements OnModuleInit {
     return this.api !== undefined;
   }
 
-  async create(name: string, spec: ShopSpec): Promise<ShopCR> {
+  async create(
+    name: string,
+    spec: DiscordChannelSpec,
+  ): Promise<DiscordChannelCR> {
     const api = this.requireApi();
-    const body: ShopCR = {
+    const body: DiscordChannelCR = {
       apiVersion: `${SHOP_CR_GROUP}/${SHOP_CR_VERSION}`,
-      kind: 'Shop',
+      kind: 'DiscordChannel',
       metadata: { name, namespace: SHOP_CR_NAMESPACE },
       spec,
     };
@@ -68,29 +70,31 @@ export class ShopCRClient implements OnModuleInit {
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: DISCORD_CHANNEL_CR_PLURAL,
         body,
       });
-      return result as ShopCR;
+      return result as DiscordChannelCR;
     } catch (err) {
       if (this.statusCode(err) === 409) {
-        throw new ConflictException(`Shop ${name} already exists in cluster`);
+        throw new ConflictException(
+          `DiscordChannel ${name} already exists in cluster`,
+        );
       }
       throw err;
     }
   }
 
-  async get(name: string): Promise<ShopCR | null> {
+  async get(name: string): Promise<DiscordChannelCR | null> {
     const api = this.requireApi();
     try {
       const result = await api.getNamespacedCustomObject({
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: DISCORD_CHANNEL_CR_PLURAL,
         name,
       });
-      return result as ShopCR;
+      return result as DiscordChannelCR;
     } catch (err) {
       if (this.statusCode(err) === 404) {
         return null;
@@ -99,18 +103,21 @@ export class ShopCRClient implements OnModuleInit {
     }
   }
 
-  async list(): Promise<ShopCR[]> {
+  async list(): Promise<DiscordChannelCR[]> {
     const api = this.requireApi();
     const result = await api.listNamespacedCustomObject({
       group: SHOP_CR_GROUP,
       version: SHOP_CR_VERSION,
       namespace: SHOP_CR_NAMESPACE,
-      plural: SHOP_CR_PLURAL,
+      plural: DISCORD_CHANNEL_CR_PLURAL,
     });
-    return (result as { items?: ShopCR[] }).items ?? [];
+    return (result as { items?: DiscordChannelCR[] }).items ?? [];
   }
 
-  async patchSpec(name: string, patch: Partial<ShopSpec>): Promise<ShopCR> {
+  async patchSpec(
+    name: string,
+    patch: Partial<DiscordChannelSpec>,
+  ): Promise<DiscordChannelCR> {
     const api = this.requireApi();
     try {
       const result = await api.patchNamespacedCustomObject(
@@ -118,16 +125,18 @@ export class ShopCRClient implements OnModuleInit {
           group: SHOP_CR_GROUP,
           version: SHOP_CR_VERSION,
           namespace: SHOP_CR_NAMESPACE,
-          plural: SHOP_CR_PLURAL,
+          plural: DISCORD_CHANNEL_CR_PLURAL,
           name,
           body: { spec: patch },
         },
         setHeaderOptions('Content-Type', PatchStrategy.MergePatch),
       );
-      return result as ShopCR;
+      return result as DiscordChannelCR;
     } catch (err) {
       if (this.statusCode(err) === 404) {
-        throw new NotFoundException(`Shop ${name} not found in cluster`);
+        throw new NotFoundException(
+          `DiscordChannel ${name} not found in cluster`,
+        );
       }
       throw err;
     }
@@ -140,7 +149,7 @@ export class ShopCRClient implements OnModuleInit {
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: DISCORD_CHANNEL_CR_PLURAL,
         name,
       });
     } catch (err) {

--- a/backend/src/k8s/discord-channel-cr.types.ts
+++ b/backend/src/k8s/discord-channel-cr.types.ts
@@ -1,0 +1,52 @@
+// TypeScript mirror of api/v1alpha1/discordchannel_types.go in shop-operator.
+// Kept in sync manually until we share a contract via OpenAPI codegen.
+
+export type DiscordSeverity = 'info' | 'warning' | 'critical';
+export type DiscordChannelPhase =
+  | 'Pending'
+  | 'Ready'
+  | 'Failed'
+  | 'Terminating';
+
+export interface DiscordWebhookSecretRef {
+  name: string;
+  key?: string;
+}
+
+export interface DiscordChannelSpec {
+  channelName: string;
+  webhookSecretRef: DiscordWebhookSecretRef;
+  shopRef?: string;
+  minSeverity?: DiscordSeverity;
+}
+
+export interface DiscordChannelCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  observedGeneration?: number;
+  lastTransitionTime?: string;
+}
+
+export interface DiscordChannelStatus {
+  phase?: DiscordChannelPhase;
+  lastValidatedAt?: string;
+  conditions?: DiscordChannelCondition[];
+  observedGeneration?: number;
+}
+
+export interface DiscordChannelCR {
+  apiVersion: 'shophub.io/v1alpha1';
+  kind: 'DiscordChannel';
+  metadata: {
+    name: string;
+    namespace: string;
+    generation?: number;
+    resourceVersion?: string;
+    uid?: string;
+    creationTimestamp?: string;
+  };
+  spec: DiscordChannelSpec;
+  status?: DiscordChannelStatus;
+}

--- a/backend/src/k8s/k8s.constants.ts
+++ b/backend/src/k8s/k8s.constants.ts
@@ -2,3 +2,8 @@ export const SHOP_CR_GROUP = 'shophub.io';
 export const SHOP_CR_VERSION = 'v1alpha1';
 export const SHOP_CR_PLURAL = 'shops';
 export const SHOP_CR_NAMESPACE = 'shophub-tenants';
+
+// DiscordChannel and Wallet share the same group/version as Shop. They live
+// in the tenant namespace alongside the Shop CRs they reference.
+export const DISCORD_CHANNEL_CR_PLURAL = 'discordchannels';
+export const WALLET_CR_PLURAL = 'wallets';

--- a/backend/src/k8s/k8s.module.ts
+++ b/backend/src/k8s/k8s.module.ts
@@ -1,8 +1,21 @@
 import { Module } from '@nestjs/common';
+import { DiscordChannelCRClient } from './discord-channel-cr.client';
+import { SecretsClient } from './secrets.client';
 import { ShopCRClient } from './shop-cr.client';
+import { WalletCRClient } from './wallet-cr.client';
 
 @Module({
-  providers: [ShopCRClient],
-  exports: [ShopCRClient],
+  providers: [
+    ShopCRClient,
+    DiscordChannelCRClient,
+    WalletCRClient,
+    SecretsClient,
+  ],
+  exports: [
+    ShopCRClient,
+    DiscordChannelCRClient,
+    WalletCRClient,
+    SecretsClient,
+  ],
 })
 export class K8sModule {}

--- a/backend/src/k8s/secrets.client.ts
+++ b/backend/src/k8s/secrets.client.ts
@@ -1,0 +1,135 @@
+import {
+  CoreV1Api,
+  KubeConfig,
+  PatchStrategy,
+  setHeaderOptions,
+} from '@kubernetes/client-node';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
+import { SHOP_CR_NAMESPACE } from './k8s.constants';
+
+/**
+ * Thin CoreV1Api wrapper for creating and rotating the Kubernetes Secrets
+ * referenced by DiscordChannel CRs. Webhook URLs land here (not in the
+ * platform database) so they stay opaque to anyone reading shophub state.
+ *
+ * All Secrets live in the same tenant namespace as the CRs that reference
+ * them, so we can use the same kubeconfig-based connection strategy as the
+ * CR clients.
+ */
+@Injectable()
+export class SecretsClient implements OnModuleInit {
+  private readonly logger = new Logger(SecretsClient.name);
+  private api?: CoreV1Api;
+  private connectionError?: Error;
+
+  onModuleInit(): void {
+    try {
+      const kc = new KubeConfig();
+      kc.loadFromDefault();
+      this.api = kc.makeApiClient(CoreV1Api);
+      const ctx = kc.getCurrentContext();
+      this.logger.log(`Kubernetes Secrets client ready (context: ${ctx})`);
+    } catch (err) {
+      this.connectionError =
+        err instanceof Error ? err : new Error(String(err));
+      this.logger.warn(
+        `Kubernetes Secrets client could not initialize: ${this.connectionError.message}.`,
+      );
+    }
+  }
+
+  isReady(): boolean {
+    return this.api !== undefined;
+  }
+
+  /**
+   * Creates an opaque Secret with the supplied key/value pairs. Throws
+   * ConflictException if a Secret with the same name already exists; callers
+   * are expected to either pick a unique name or call upsert via patch.
+   */
+  async create(name: string, data: Record<string, string>): Promise<void> {
+    const api = this.requireApi();
+    try {
+      await api.createNamespacedSecret({
+        namespace: SHOP_CR_NAMESPACE,
+        body: {
+          apiVersion: 'v1',
+          kind: 'Secret',
+          metadata: { name, namespace: SHOP_CR_NAMESPACE },
+          type: 'Opaque',
+          stringData: data,
+        },
+      });
+    } catch (err) {
+      if (this.statusCode(err) === 409) {
+        throw new ConflictException(`Secret ${name} already exists in cluster`);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Merge-patches the Secret's stringData. Used to rotate webhook URLs
+   * without losing other keys that future reconcilers might add.
+   */
+  async patchStringData(
+    name: string,
+    data: Record<string, string>,
+  ): Promise<void> {
+    const api = this.requireApi();
+    try {
+      await api.patchNamespacedSecret(
+        {
+          name,
+          namespace: SHOP_CR_NAMESPACE,
+          body: { stringData: data },
+        },
+        setHeaderOptions('Content-Type', PatchStrategy.MergePatch),
+      );
+    } catch (err) {
+      if (this.statusCode(err) === 404) {
+        throw new NotFoundException(`Secret ${name} not found in cluster`);
+      }
+      throw err;
+    }
+  }
+
+  async delete(name: string): Promise<void> {
+    const api = this.requireApi();
+    try {
+      await api.deleteNamespacedSecret({ name, namespace: SHOP_CR_NAMESPACE });
+    } catch (err) {
+      if (this.statusCode(err) === 404) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private requireApi(): CoreV1Api {
+    if (!this.api) {
+      throw new Error(
+        `Kubernetes client not available: ${this.connectionError?.message ?? 'unknown reason'}`,
+      );
+    }
+    return this.api;
+  }
+
+  private statusCode(err: unknown): number | undefined {
+    if (typeof err !== 'object' || err === null) return undefined;
+    const candidate = err as {
+      code?: number;
+      statusCode?: number;
+      response?: { statusCode?: number };
+    };
+    return (
+      candidate.code ?? candidate.statusCode ?? candidate.response?.statusCode
+    );
+  }
+}

--- a/backend/src/k8s/wallet-cr.client.ts
+++ b/backend/src/k8s/wallet-cr.client.ts
@@ -5,32 +5,27 @@ import {
   setHeaderOptions,
 } from '@kubernetes/client-node';
 import {
+  ConflictException,
   Injectable,
   Logger,
   NotFoundException,
   OnModuleInit,
-  ConflictException,
 } from '@nestjs/common';
 import {
   SHOP_CR_GROUP,
   SHOP_CR_NAMESPACE,
-  SHOP_CR_PLURAL,
   SHOP_CR_VERSION,
+  WALLET_CR_PLURAL,
 } from './k8s.constants';
-import { ShopCR, ShopSpec } from './shop-cr.types';
+import { WalletCR, WalletSpec } from './wallet-cr.types';
 
 /**
- * Wraps @kubernetes/client-node CustomObjectsApi for the Shop CRD.
- *
- * Connection strategy mirrors the official client default: try in-cluster
- * (mounted ServiceAccount token) first, fall back to ~/.kube/config for
- * local development. If neither is available the module still boots so
- * that unrelated requests (auth, health) keep working - K8s calls then
- * fail at request time with a descriptive error.
+ * Wraps @kubernetes/client-node CustomObjectsApi for the Wallet CRD.
+ * Mirrors the connection strategy of ShopCRClient.
  */
 @Injectable()
-export class ShopCRClient implements OnModuleInit {
-  private readonly logger = new Logger(ShopCRClient.name);
+export class WalletCRClient implements OnModuleInit {
+  private readonly logger = new Logger(WalletCRClient.name);
   private api?: CustomObjectsApi;
   private connectionError?: Error;
 
@@ -46,7 +41,7 @@ export class ShopCRClient implements OnModuleInit {
         err instanceof Error ? err : new Error(String(err));
       this.logger.warn(
         `Kubernetes client could not initialize: ${this.connectionError.message}. ` +
-          'Shop CR operations will fail until kubeconfig or in-cluster credentials are available.',
+          'Wallet CR operations will fail until kubeconfig or in-cluster credentials are available.',
       );
     }
   }
@@ -55,11 +50,11 @@ export class ShopCRClient implements OnModuleInit {
     return this.api !== undefined;
   }
 
-  async create(name: string, spec: ShopSpec): Promise<ShopCR> {
+  async create(name: string, spec: WalletSpec): Promise<WalletCR> {
     const api = this.requireApi();
-    const body: ShopCR = {
+    const body: WalletCR = {
       apiVersion: `${SHOP_CR_GROUP}/${SHOP_CR_VERSION}`,
-      kind: 'Shop',
+      kind: 'Wallet',
       metadata: { name, namespace: SHOP_CR_NAMESPACE },
       spec,
     };
@@ -68,29 +63,29 @@ export class ShopCRClient implements OnModuleInit {
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: WALLET_CR_PLURAL,
         body,
       });
-      return result as ShopCR;
+      return result as WalletCR;
     } catch (err) {
       if (this.statusCode(err) === 409) {
-        throw new ConflictException(`Shop ${name} already exists in cluster`);
+        throw new ConflictException(`Wallet ${name} already exists in cluster`);
       }
       throw err;
     }
   }
 
-  async get(name: string): Promise<ShopCR | null> {
+  async get(name: string): Promise<WalletCR | null> {
     const api = this.requireApi();
     try {
       const result = await api.getNamespacedCustomObject({
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: WALLET_CR_PLURAL,
         name,
       });
-      return result as ShopCR;
+      return result as WalletCR;
     } catch (err) {
       if (this.statusCode(err) === 404) {
         return null;
@@ -99,18 +94,18 @@ export class ShopCRClient implements OnModuleInit {
     }
   }
 
-  async list(): Promise<ShopCR[]> {
+  async list(): Promise<WalletCR[]> {
     const api = this.requireApi();
     const result = await api.listNamespacedCustomObject({
       group: SHOP_CR_GROUP,
       version: SHOP_CR_VERSION,
       namespace: SHOP_CR_NAMESPACE,
-      plural: SHOP_CR_PLURAL,
+      plural: WALLET_CR_PLURAL,
     });
-    return (result as { items?: ShopCR[] }).items ?? [];
+    return (result as { items?: WalletCR[] }).items ?? [];
   }
 
-  async patchSpec(name: string, patch: Partial<ShopSpec>): Promise<ShopCR> {
+  async patchSpec(name: string, patch: Partial<WalletSpec>): Promise<WalletCR> {
     const api = this.requireApi();
     try {
       const result = await api.patchNamespacedCustomObject(
@@ -118,16 +113,16 @@ export class ShopCRClient implements OnModuleInit {
           group: SHOP_CR_GROUP,
           version: SHOP_CR_VERSION,
           namespace: SHOP_CR_NAMESPACE,
-          plural: SHOP_CR_PLURAL,
+          plural: WALLET_CR_PLURAL,
           name,
           body: { spec: patch },
         },
         setHeaderOptions('Content-Type', PatchStrategy.MergePatch),
       );
-      return result as ShopCR;
+      return result as WalletCR;
     } catch (err) {
       if (this.statusCode(err) === 404) {
-        throw new NotFoundException(`Shop ${name} not found in cluster`);
+        throw new NotFoundException(`Wallet ${name} not found in cluster`);
       }
       throw err;
     }
@@ -140,7 +135,7 @@ export class ShopCRClient implements OnModuleInit {
         group: SHOP_CR_GROUP,
         version: SHOP_CR_VERSION,
         namespace: SHOP_CR_NAMESPACE,
-        plural: SHOP_CR_PLURAL,
+        plural: WALLET_CR_PLURAL,
         name,
       });
     } catch (err) {

--- a/backend/src/k8s/wallet-cr.types.ts
+++ b/backend/src/k8s/wallet-cr.types.ts
@@ -1,0 +1,43 @@
+// TypeScript mirror of api/v1alpha1/wallet_types.go in shop-operator.
+// Kept in sync manually until we share a contract via OpenAPI codegen.
+
+export type WalletPurpose = 'payments' | 'payout';
+export type WalletPhase = 'Pending' | 'Ready' | 'Failed' | 'Terminating';
+
+export interface WalletSpec {
+  displayName: string;
+  address: string;
+  chainId?: number;
+  purpose?: WalletPurpose;
+  ownerRef?: string;
+}
+
+export interface WalletCondition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+  observedGeneration?: number;
+  lastTransitionTime?: string;
+}
+
+export interface WalletStatus {
+  phase?: WalletPhase;
+  conditions?: WalletCondition[];
+  observedGeneration?: number;
+}
+
+export interface WalletCR {
+  apiVersion: 'shophub.io/v1alpha1';
+  kind: 'Wallet';
+  metadata: {
+    name: string;
+    namespace: string;
+    generation?: number;
+    resourceVersion?: string;
+    uid?: string;
+    creationTimestamp?: string;
+  };
+  spec: WalletSpec;
+  status?: WalletStatus;
+}

--- a/backend/src/shops/dto/create-shop.dto.ts
+++ b/backend/src/shops/dto/create-shop.dto.ts
@@ -10,7 +10,8 @@ import {
   MinLength,
 } from 'class-validator';
 
-const HOST_PATTERN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$/;
+const HOST_PATTERN =
+  /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$/;
 
 export class CreateShopDto {
   @IsString()

--- a/backend/src/shops/entities/shop.entity.ts
+++ b/backend/src/shops/entities/shop.entity.ts
@@ -16,14 +16,8 @@ import type {
 } from '../../k8s/shop-cr.types';
 
 @Entity({ name: 'shops' })
-@Check(
-  'chk_shops_availability',
-  `"availability" IN ('standard', 'high')`,
-)
-@Check(
-  'chk_shops_database_tier',
-  `"database_tier" IN ('standard', 'light')`,
-)
+@Check('chk_shops_availability', `"availability" IN ('standard', 'high')`)
+@Check('chk_shops_database_tier', `"database_tier" IN ('standard', 'light')`)
 @Index('uniq_shops_k8s_name', ['k8sName'], { unique: true })
 @Index('uniq_shops_host', ['host'], { unique: true })
 @Index('idx_shops_user_id', ['userId'])
@@ -59,16 +53,36 @@ export class Shop {
   @Column({ name: 'chain_id', type: 'bigint', default: 11155111 })
   chainId!: string;
 
-  @Column({ name: 'backend_image', type: 'varchar', length: 255, nullable: true })
+  @Column({
+    name: 'backend_image',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
   backendImage!: string | null;
 
-  @Column({ name: 'frontend_image', type: 'varchar', length: 255, nullable: true })
+  @Column({
+    name: 'frontend_image',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
   frontendImage!: string | null;
 
-  @Column({ name: 'last_known_phase', type: 'varchar', length: 16, nullable: true })
+  @Column({
+    name: 'last_known_phase',
+    type: 'varchar',
+    length: 16,
+    nullable: true,
+  })
   lastKnownPhase!: ShopPhase | null;
 
-  @Column({ name: 'last_known_url', type: 'varchar', length: 512, nullable: true })
+  @Column({
+    name: 'last_known_url',
+    type: 'varchar',
+    length: 512,
+    nullable: true,
+  })
   lastKnownUrl!: string | null;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -42,30 +42,31 @@ describe('ShopsService (unit)', () => {
     chainId: 11155111,
   };
 
-  const buildShop = (over: Partial<Shop> = {}): Shop =>
-    ({
-      id: 'shop-id-1',
-      userId: ownerId,
-      k8sName: 'shop-deadbeef',
-      displayName: 'Demo',
-      host: 'demo.shophub.local',
-      availability: 'standard',
-      databaseTier: 'standard',
-      walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
-      chainId: '11155111',
-      backendImage: null,
-      frontendImage: null,
-      lastKnownPhase: null,
-      lastKnownUrl: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      normalize: () => undefined,
-      ...over,
-    }) as Shop;
+  const buildShop = (over: Partial<Shop> = {}): Shop => ({
+    id: 'shop-id-1',
+    userId: ownerId,
+    k8sName: 'shop-deadbeef',
+    displayName: 'Demo',
+    host: 'demo.shophub.local',
+    availability: 'standard',
+    databaseTier: 'standard',
+    walletAddress: '0xabcdef1234567890abcdef1234567890abcdef12',
+    chainId: '11155111',
+    backendImage: null,
+    frontendImage: null,
+    lastKnownPhase: null,
+    lastKnownUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    normalize: () => undefined,
+    ...over,
+  });
 
   beforeEach(async () => {
     const repoMock: Partial<jest.Mocked<Repository<Shop>>> = {
-      create: jest.fn().mockImplementation((data: Partial<Shop>) => buildShop(data)),
+      create: jest
+        .fn()
+        .mockImplementation((data: Partial<Shop>) => buildShop(data)),
       save: jest.fn().mockImplementation((shop: Shop) => Promise.resolve(shop)),
       find: jest.fn(),
       findOne: jest.fn(),
@@ -118,9 +119,9 @@ describe('ShopsService (unit)', () => {
     it('rolls back the DB row when the CR create fails', async () => {
       k8s.create.mockRejectedValue(new Error('cluster unreachable'));
 
-      await expect(
-        service.createForUser(ownerId, sampleInput),
-      ).rejects.toThrow('cluster unreachable');
+      await expect(service.createForUser(ownerId, sampleInput)).rejects.toThrow(
+        'cluster unreachable',
+      );
 
       expect(repo.delete).toHaveBeenCalledTimes(1);
     });
@@ -146,7 +147,7 @@ describe('ShopsService (unit)', () => {
       expect(got).toBe(shop);
     });
 
-    it("throws NotFoundException when the shop belongs to another user", async () => {
+    it('throws NotFoundException when the shop belongs to another user', async () => {
       repo.findOne.mockResolvedValue(null);
 
       await expect(
@@ -169,7 +170,9 @@ describe('ShopsService (unit)', () => {
       const [name, spec] = k8s.patchSpec.mock.calls[0];
       expect(name).toBe(existing.k8sName);
       expect(spec.availability).toBe('high');
-      expect(spec.walletAddress).toBe('0x1111111111111111111111111111111111111111');
+      expect(spec.walletAddress).toBe(
+        '0x1111111111111111111111111111111111111111',
+      );
     });
   });
 

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -105,12 +105,17 @@ export class ShopsService {
     const shop = await this.findOneForUser(userId, id);
 
     if (input.displayName !== undefined) shop.displayName = input.displayName;
-    if (input.availability !== undefined) shop.availability = input.availability;
-    if (input.databaseTier !== undefined) shop.databaseTier = input.databaseTier;
-    if (input.walletAddress !== undefined) shop.walletAddress = input.walletAddress;
+    if (input.availability !== undefined)
+      shop.availability = input.availability;
+    if (input.databaseTier !== undefined)
+      shop.databaseTier = input.databaseTier;
+    if (input.walletAddress !== undefined)
+      shop.walletAddress = input.walletAddress;
     if (input.chainId !== undefined) shop.chainId = String(input.chainId);
-    if (input.backendImage !== undefined) shop.backendImage = input.backendImage;
-    if (input.frontendImage !== undefined) shop.frontendImage = input.frontendImage;
+    if (input.backendImage !== undefined)
+      shop.backendImage = input.backendImage;
+    if (input.frontendImage !== undefined)
+      shop.frontendImage = input.frontendImage;
 
     const saved = await this.shops.save(shop);
     await this.k8s.patchSpec(saved.k8sName, shopEntityToCRSpec(saved));

--- a/backend/src/wallets/dto/create-wallet.dto.ts
+++ b/backend/src/wallets/dto/create-wallet.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsEnum,
+  IsEthereumAddress,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+export class CreateWalletDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  displayName!: string;
+
+  @IsEthereumAddress()
+  address!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  chainId?: number;
+
+  @IsOptional()
+  @IsEnum(['payments', 'payout'] as const)
+  purpose?: 'payments' | 'payout';
+}

--- a/backend/src/wallets/dto/update-wallet.dto.ts
+++ b/backend/src/wallets/dto/update-wallet.dto.ts
@@ -1,0 +1,22 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+// address and chainId are immutable after creation - a wallet's identity is
+// its (address, chainId) pair. Users who want a different address create a
+// new Wallet record.
+export class UpdateWalletDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  displayName?: string;
+
+  @IsOptional()
+  @IsEnum(['payments', 'payout'] as const)
+  purpose?: 'payments' | 'payout';
+}

--- a/backend/src/wallets/entities/wallet.entity.ts
+++ b/backend/src/wallets/entities/wallet.entity.ts
@@ -1,0 +1,64 @@
+import {
+  BeforeInsert,
+  BeforeUpdate,
+  Check,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type { WalletPhase, WalletPurpose } from '../../k8s/wallet-cr.types';
+
+@Entity({ name: 'wallets' })
+@Check('chk_wallets_purpose', `"purpose" IN ('payments', 'payout')`)
+@Index('uniq_wallets_k8s_name', ['k8sName'], { unique: true })
+@Index('idx_wallets_user_id', ['userId'])
+@Index('idx_wallets_address', ['address'])
+export class Wallet {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  /**
+   * Auto-generated DNS-1123 label used as the Wallet CR's metadata.name.
+   * Immutable after creation; users never see it directly.
+   */
+  @Column({ name: 'k8s_name', type: 'varchar', length: 63 })
+  k8sName!: string;
+
+  @Column({ name: 'display_name', type: 'varchar', length: 80 })
+  displayName!: string;
+
+  @Column({ type: 'varchar', length: 42 })
+  address!: string;
+
+  @Column({ name: 'chain_id', type: 'bigint', default: 11155111 })
+  chainId!: string;
+
+  @Column({ type: 'varchar', length: 16 })
+  purpose!: WalletPurpose;
+
+  @Column({ name: 'last_known_phase', type: 'varchar', length: 16, nullable: true })
+  lastKnownPhase!: WalletPhase | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  normalize(): void {
+    if (this.address) {
+      this.address = this.address.toLowerCase();
+    }
+    if (this.k8sName) {
+      this.k8sName = this.k8sName.toLowerCase();
+    }
+  }
+}

--- a/backend/src/wallets/wallets-status.poller.ts
+++ b/backend/src/wallets/wallets-status.poller.ts
@@ -1,0 +1,21 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { WalletsService } from './wallets.service';
+
+@Injectable()
+export class WalletsStatusPoller {
+  private readonly logger = new Logger(WalletsStatusPoller.name);
+
+  constructor(private readonly wallets: WalletsService) {}
+
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async sweep(): Promise<void> {
+    try {
+      await this.wallets.syncAllStatuses();
+    } catch (err) {
+      this.logger.warn(
+        `Status sweep failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/backend/src/wallets/wallets.controller.ts
+++ b/backend/src/wallets/wallets.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { User } from '../users/entities/user.entity';
+import { CreateWalletDto } from './dto/create-wallet.dto';
+import { UpdateWalletDto } from './dto/update-wallet.dto';
+import { Wallet } from './entities/wallet.entity';
+import { WalletsService } from './wallets.service';
+
+@Controller('wallets')
+@UseGuards(JwtAuthGuard)
+export class WalletsController {
+  constructor(private readonly wallets: WalletsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@CurrentUser() user: User, @Body() dto: CreateWalletDto): Promise<Wallet> {
+    return this.wallets.createForUser(user.id, dto);
+  }
+
+  @Get()
+  list(@CurrentUser() user: User): Promise<Wallet[]> {
+    return this.wallets.findAllForUser(user.id);
+  }
+
+  @Get(':id')
+  get(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<Wallet> {
+    return this.wallets.findOneForUser(user.id, id);
+  }
+
+  @Patch(':id')
+  update(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateWalletDto,
+  ): Promise<Wallet> {
+    return this.wallets.updateForUser(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.wallets.deleteForUser(user.id, id);
+  }
+}

--- a/backend/src/wallets/wallets.mapper.ts
+++ b/backend/src/wallets/wallets.mapper.ts
@@ -1,0 +1,17 @@
+import { WalletSpec } from '../k8s/wallet-cr.types';
+import { Wallet } from './entities/wallet.entity';
+
+/**
+ * Translates a Wallet database row into the spec the operator expects.
+ * ownerRef carries the userId so the CR is auditable back to its owner
+ * without joining the platform DB.
+ */
+export function walletEntityToCRSpec(wallet: Wallet): WalletSpec {
+  return {
+    displayName: wallet.displayName,
+    address: wallet.address,
+    chainId: Number(wallet.chainId),
+    purpose: wallet.purpose,
+    ownerRef: wallet.userId,
+  };
+}

--- a/backend/src/wallets/wallets.module.ts
+++ b/backend/src/wallets/wallets.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { K8sModule } from '../k8s/k8s.module';
+import { UsersModule } from '../users/users.module';
+import { Wallet } from './entities/wallet.entity';
+import { WalletsController } from './wallets.controller';
+import { WalletsService } from './wallets.service';
+import { WalletsStatusPoller } from './wallets-status.poller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Wallet]),
+    AuthModule,
+    K8sModule,
+    UsersModule,
+  ],
+  controllers: [WalletsController],
+  providers: [WalletsService, WalletsStatusPoller],
+  exports: [WalletsService],
+})
+export class WalletsModule {}

--- a/backend/src/wallets/wallets.service.spec.ts
+++ b/backend/src/wallets/wallets.service.spec.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+jest.mock('@kubernetes/client-node', () => ({
+  CustomObjectsApi: class {},
+  CoreV1Api: class {},
+  KubeConfig: class {
+    loadFromDefault(): void {}
+    makeApiClient(): unknown {
+      return {};
+    }
+    getCurrentContext(): string {
+      return 'mock';
+    }
+  },
+  PatchStrategy: { MergePatch: 'application/merge-patch+json' },
+  setHeaderOptions: () => ({}),
+}));
+
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { QueryFailedError, Repository } from 'typeorm';
+import { WalletCRClient } from '../k8s/wallet-cr.client';
+import { Wallet } from './entities/wallet.entity';
+import { WalletsService } from './wallets.service';
+
+describe('WalletsService (unit)', () => {
+  let service: WalletsService;
+  let repo: jest.Mocked<Repository<Wallet>>;
+  let k8s: jest.Mocked<WalletCRClient>;
+
+  const ownerId = '00000000-0000-0000-0000-000000000001';
+  const otherId = '00000000-0000-0000-0000-000000000002';
+
+  const sampleInput = {
+    displayName: 'Main wallet',
+    address: '0xabcdef1234567890abcdef1234567890abcdef12',
+  };
+
+  const buildWallet = (over: Partial<Wallet> = {}): Wallet => ({
+    id: 'wallet-id-1',
+    userId: ownerId,
+    k8sName: 'wallet-deadbeef',
+    displayName: 'Main wallet',
+    address: '0xabcdef1234567890abcdef1234567890abcdef12',
+    chainId: '11155111',
+    purpose: 'payments',
+    lastKnownPhase: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    normalize: () => undefined,
+    ...over,
+  });
+
+  beforeEach(async () => {
+    const repoMock: Partial<jest.Mocked<Repository<Wallet>>> = {
+      create: jest
+        .fn()
+        .mockImplementation((data: Partial<Wallet>) => buildWallet(data)),
+      save: jest
+        .fn()
+        .mockImplementation((wallet: Wallet) => Promise.resolve(wallet)),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const k8sMock: Partial<jest.Mocked<WalletCRClient>> = {
+      isReady: jest.fn().mockReturnValue(true),
+      create: jest.fn(),
+      get: jest.fn(),
+      list: jest.fn(),
+      patchSpec: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        WalletsService,
+        { provide: getRepositoryToken(Wallet), useValue: repoMock },
+        { provide: WalletCRClient, useValue: k8sMock },
+      ],
+    }).compile();
+
+    service = moduleRef.get(WalletsService);
+    repo = moduleRef.get(getRepositoryToken(Wallet));
+    k8s = moduleRef.get(WalletCRClient);
+  });
+
+  describe('createForUser', () => {
+    it('persists the wallet, defaults purpose and chainId, and creates the CR', async () => {
+      await service.createForUser(ownerId, sampleInput);
+
+      expect(repo.save).toHaveBeenCalledTimes(1);
+      const saved = repo.save.mock.calls[0][0] as Wallet;
+      expect(saved.userId).toBe(ownerId);
+      expect(saved.k8sName).toMatch(/^wallet-[a-f0-9]{8}$/);
+      expect(saved.purpose).toBe('payments');
+      expect(saved.chainId).toBe('11155111');
+
+      expect(k8s.create).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8s.create.mock.calls[0];
+      expect(name).toBe(saved.k8sName);
+      expect(spec).toMatchObject({
+        displayName: 'Main wallet',
+        address: '0xabcdef1234567890abcdef1234567890abcdef12',
+        chainId: 11155111,
+        purpose: 'payments',
+        ownerRef: ownerId,
+      });
+    });
+
+    it('rolls back the DB row when the CR create fails', async () => {
+      k8s.create.mockRejectedValue(new Error('cluster unreachable'));
+
+      await expect(service.createForUser(ownerId, sampleInput)).rejects.toThrow(
+        'cluster unreachable',
+      );
+      expect(repo.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('translates DB unique violations to ConflictException', async () => {
+      const err = new QueryFailedError('q', [], new Error('dup'));
+      (err as QueryFailedError & { code?: string }).code = '23505';
+      repo.save.mockRejectedValueOnce(err);
+
+      await expect(
+        service.createForUser(ownerId, sampleInput),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(k8s.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOneForUser', () => {
+    it('throws NotFoundException when the wallet belongs to someone else', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.findOneForUser(otherId, 'wallet-id-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateForUser', () => {
+    it('patches the CR with the merged spec', async () => {
+      repo.findOne.mockResolvedValue(buildWallet());
+
+      await service.updateForUser(ownerId, 'wallet-id-1', {
+        displayName: 'Renamed',
+        purpose: 'payout',
+      });
+
+      expect(k8s.patchSpec).toHaveBeenCalledTimes(1);
+      const [name, spec] = k8s.patchSpec.mock.calls[0];
+      expect(name).toBe('wallet-deadbeef');
+      expect(spec.displayName).toBe('Renamed');
+      expect(spec.purpose).toBe('payout');
+    });
+  });
+
+  describe('deleteForUser', () => {
+    it('deletes the CR before deleting the DB row', async () => {
+      repo.findOne.mockResolvedValue(buildWallet());
+      const order: string[] = [];
+      k8s.delete.mockImplementation(async () => {
+        order.push('cr');
+      });
+      repo.delete.mockImplementation(async () => {
+        order.push('db');
+        return { affected: 1, raw: [] };
+      });
+
+      await service.deleteForUser(ownerId, 'wallet-id-1');
+
+      expect(order).toEqual(['cr', 'db']);
+    });
+  });
+
+  describe('syncAllStatuses', () => {
+    it('copies phase from the CR to the DB', async () => {
+      const wallet = buildWallet();
+      repo.find.mockResolvedValue([wallet]);
+      k8s.get.mockResolvedValue({
+        apiVersion: 'shophub.io/v1alpha1',
+        kind: 'Wallet',
+        metadata: { name: wallet.k8sName, namespace: 'shophub-tenants' },
+        spec: {
+          displayName: wallet.displayName,
+          address: wallet.address,
+          chainId: 11155111,
+          purpose: wallet.purpose,
+          ownerRef: wallet.userId,
+        },
+        status: { phase: 'Ready' },
+      });
+
+      await service.syncAllStatuses();
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ lastKnownPhase: 'Ready' }),
+      );
+    });
+
+    it('does nothing when the K8s client is not ready', async () => {
+      k8s.isReady.mockReturnValue(false);
+      await service.syncAllStatuses();
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/wallets/wallets.service.ts
+++ b/backend/src/wallets/wallets.service.ts
@@ -1,0 +1,149 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { QueryFailedError, Repository } from 'typeorm';
+import { WalletCRClient } from '../k8s/wallet-cr.client';
+import { Wallet } from './entities/wallet.entity';
+import { walletEntityToCRSpec } from './wallets.mapper';
+
+const PG_UNIQUE_VIOLATION = '23505';
+const DEFAULT_PURPOSE = 'payments';
+const DEFAULT_CHAIN_ID = 11155111;
+
+export interface CreateWalletInput {
+  displayName: string;
+  address: string;
+  chainId?: number;
+  purpose?: 'payments' | 'payout';
+}
+
+export interface UpdateWalletInput {
+  displayName?: string;
+  purpose?: 'payments' | 'payout';
+}
+
+@Injectable()
+export class WalletsService {
+  private readonly logger = new Logger(WalletsService.name);
+
+  constructor(
+    @InjectRepository(Wallet)
+    private readonly wallets: Repository<Wallet>,
+    private readonly k8s: WalletCRClient,
+  ) {}
+
+  async createForUser(userId: string, input: CreateWalletInput): Promise<Wallet> {
+    const wallet = this.wallets.create({
+      userId,
+      k8sName: generateWalletK8sName(),
+      displayName: input.displayName,
+      address: input.address,
+      chainId: String(input.chainId ?? DEFAULT_CHAIN_ID),
+      purpose: input.purpose ?? DEFAULT_PURPOSE,
+    });
+
+    let saved: Wallet;
+    try {
+      saved = await this.wallets.save(wallet);
+    } catch (err) {
+      if (this.isUniqueViolation(err)) {
+        throw new ConflictException('Wallet name collision; please retry');
+      }
+      throw err;
+    }
+
+    try {
+      await this.k8s.create(saved.k8sName, walletEntityToCRSpec(saved));
+    } catch (err) {
+      this.logger.error(
+        `Failed to create Wallet CR ${saved.k8sName}, rolling back DB row`,
+        err instanceof Error ? err.stack : String(err),
+      );
+      await this.wallets.delete(saved.id);
+      throw err;
+    }
+    return saved;
+  }
+
+  findAllForUser(userId: string): Promise<Wallet[]> {
+    return this.wallets.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOneForUser(userId: string, id: string): Promise<Wallet> {
+    const wallet = await this.wallets.findOne({ where: { id, userId } });
+    if (!wallet) {
+      throw new NotFoundException('Wallet not found');
+    }
+    return wallet;
+  }
+
+  async updateForUser(
+    userId: string,
+    id: string,
+    input: UpdateWalletInput,
+  ): Promise<Wallet> {
+    const wallet = await this.findOneForUser(userId, id);
+
+    if (input.displayName !== undefined) wallet.displayName = input.displayName;
+    if (input.purpose !== undefined) wallet.purpose = input.purpose;
+
+    const saved = await this.wallets.save(wallet);
+    await this.k8s.patchSpec(saved.k8sName, walletEntityToCRSpec(saved));
+    return saved;
+  }
+
+  async deleteForUser(userId: string, id: string): Promise<void> {
+    const wallet = await this.findOneForUser(userId, id);
+    await this.k8s.delete(wallet.k8sName);
+    await this.wallets.delete(wallet.id);
+  }
+
+  /**
+   * Sweeps every Wallet row and copies the latest phase from its CR status
+   * into the DB. Intended to be called from a scheduled job.
+   */
+  async syncAllStatuses(): Promise<void> {
+    if (!this.k8s.isReady()) {
+      return;
+    }
+    const wallets = await this.wallets.find();
+    for (const wallet of wallets) {
+      try {
+        const cr = await this.k8s.get(wallet.k8sName);
+        if (!cr) {
+          continue;
+        }
+        const phase = cr.status?.phase ?? null;
+        if (phase !== wallet.lastKnownPhase) {
+          wallet.lastKnownPhase = phase;
+          await this.wallets.save(wallet);
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Status sync failed for wallet ${wallet.k8sName}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  private isUniqueViolation(err: unknown): boolean {
+    return (
+      err instanceof QueryFailedError &&
+      (err as QueryFailedError & { code?: string }).code === PG_UNIQUE_VIOLATION
+    );
+  }
+}
+
+function generateWalletK8sName(): string {
+  return `wallet-${randomBytes(4).toString('hex')}`;
+}

--- a/backend/test/integration/shops.int-spec.ts
+++ b/backend/test/integration/shops.int-spec.ts
@@ -139,7 +139,11 @@ describe('Shops (integration)', () => {
       const res = await request(app.getHttpServer())
         .post('/shops')
         .set('Authorization', `Bearer ${token}`)
-        .send({ ...validShop, host: 'bad.shophub.local', walletAddress: 'not-an-address' });
+        .send({
+          ...validShop,
+          host: 'bad.shophub.local',
+          walletAddress: 'not-an-address',
+        });
       expect(res.status).toBe(400);
     });
   });

--- a/frontend/src/app/discord-channels/[id]/page.tsx
+++ b/frontend/src/app/discord-channels/[id]/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import {
+  DiscordChannel,
+  DiscordSeverity,
+  discordPhaseColorClass,
+} from '@/lib/discord-channel-types';
+import { Shop } from '@/lib/shop-types';
+
+const editInputClass =
+  'w-full rounded border border-zinc-300 bg-white px-2 py-1 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100';
+
+export default function DiscordChannelDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [channel, setChannel] = useState<DiscordChannel | null>(null);
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const id = params.id;
+
+  const fetchChannel = useCallback(() => {
+    api
+      .getDiscordChannel(id)
+      .then(setChannel)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) {
+          setError('Channel not found');
+        } else if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to load channel');
+        }
+      });
+  }, [id]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    fetchChannel();
+    api.listShops().then(setShops).catch(() => undefined);
+    const interval = setInterval(() => {
+      if (!editing) fetchChannel();
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router, fetchChannel, editing]);
+
+  const onDelete = async () => {
+    if (!channel) return;
+    if (!window.confirm(`Delete channel "${channel.channelName}"?`)) return;
+    setDeleting(true);
+    try {
+      await api.deleteDiscordChannel(channel.id);
+      router.push('/discord-channels');
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to delete channel');
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+  if (error && !channel) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+      </div>
+    );
+  }
+  if (!channel) {
+    return <div className="p-8 text-zinc-500">Loading channel...</div>;
+  }
+
+  const attachedShop = shops.find((s) => s.id === channel.shopId);
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-3xl px-8 py-12">
+        <div className="mb-2 text-sm text-zinc-500">
+          <button
+            type="button"
+            onClick={() => router.push('/discord-channels')}
+            className="underline"
+          >
+            ← All channels
+          </button>
+        </div>
+
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+              {channel.channelName}
+            </h1>
+            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+              {attachedShop
+                ? `Scoped to ${attachedShop.displayName}`
+                : 'All shops in namespace'}
+            </p>
+          </div>
+          <span
+            className={`rounded px-3 py-1 text-sm font-medium ${discordPhaseColorClass(channel.lastKnownPhase)}`}
+          >
+            {channel.lastKnownPhase ?? 'Pending'}
+          </span>
+        </div>
+
+        {editing ? (
+          <EditPanel
+            channel={channel}
+            shops={shops}
+            onCancel={() => setEditing(false)}
+            onSaved={(updated) => {
+              setChannel(updated);
+              setEditing(false);
+            }}
+            onError={setError}
+            externalError={error}
+          />
+        ) : (
+          <>
+            <dl className="grid grid-cols-2 gap-4 rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <Field label="Minimum severity">{channel.minSeverity}</Field>
+              <Field label="Attached shop">
+                {attachedShop ? attachedShop.displayName : 'all shops'}
+              </Field>
+              <Field label="Secret">
+                <span className="font-mono text-xs">{channel.secretName}</span>
+              </Field>
+              <Field label="Created">
+                {new Date(channel.createdAt).toLocaleString()}
+              </Field>
+              <Field label="K8s name">
+                <span className="font-mono text-xs">{channel.k8sName}</span>
+              </Field>
+            </dl>
+
+            {error && (
+              <p className="mt-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+            )}
+
+            <div className="mt-6 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  setEditing(true);
+                }}
+                className="rounded border border-zinc-300 px-4 py-2 text-sm hover:bg-black/[.04] dark:border-zinc-700 dark:hover:bg-white/[.04]"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={deleting}
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? 'Deleting...' : 'Delete channel'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditPanel({
+  channel,
+  shops,
+  onCancel,
+  onSaved,
+  onError,
+  externalError,
+}: {
+  channel: DiscordChannel;
+  shops: Shop[];
+  onCancel: () => void;
+  onSaved: (updated: DiscordChannel) => void;
+  onError: (msg: string | null) => void;
+  externalError: string | null;
+}) {
+  const [channelName, setChannelName] = useState(channel.channelName);
+  const [minSeverity, setMinSeverity] = useState<DiscordSeverity>(
+    channel.minSeverity,
+  );
+  const [shopId, setShopId] = useState<string>(channel.shopId ?? '');
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    onError(null);
+    try {
+      const updated = await api.updateDiscordChannel(channel.id, {
+        channelName,
+        minSeverity,
+        shopId: shopId === '' ? null : shopId,
+        ...(webhookUrl ? { webhookUrl } : {}),
+      });
+      onSaved(updated);
+    } catch (err) {
+      onError(err instanceof ApiError ? err.message : 'Failed to save changes');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Channel name">
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={channelName}
+            onChange={(e) => setChannelName(e.target.value)}
+            className={editInputClass}
+          />
+        </Field>
+        <Field label="Minimum severity">
+          <select
+            value={minSeverity}
+            onChange={(e) => setMinSeverity(e.target.value as DiscordSeverity)}
+            className={editInputClass}
+          >
+            <option value="info">info</option>
+            <option value="warning">warning</option>
+            <option value="critical">critical</option>
+          </select>
+        </Field>
+        <Field label="Attached shop">
+          <select
+            value={shopId}
+            onChange={(e) => setShopId(e.target.value)}
+            className={editInputClass}
+          >
+            <option value="">All my shops</option>
+            {shops.map((shop) => (
+              <option key={shop.id} value={shop.id}>
+                {shop.displayName} ({shop.host})
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="K8s name (read-only)">
+          <span className="font-mono text-xs text-zinc-500">{channel.k8sName}</span>
+        </Field>
+        <div className="col-span-2">
+          <Field label="Rotate webhook URL (optional)">
+            <input
+              type="url"
+              pattern="https://.*"
+              placeholder="Leave blank to keep the current URL"
+              value={webhookUrl}
+              onChange={(e) => setWebhookUrl(e.target.value)}
+              className={`${editInputClass} font-mono text-xs`}
+            />
+          </Field>
+        </div>
+      </div>
+
+      {externalError && (
+        <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+          {externalError}
+        </p>
+      )}
+
+      <div className="mt-6 flex gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+        >
+          {saving ? 'Saving...' : 'Save changes'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-black dark:text-zinc-100">{children}</dd>
+    </div>
+  );
+}

--- a/frontend/src/app/discord-channels/new/page.tsx
+++ b/frontend/src/app/discord-channels/new/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import { DiscordSeverity } from '@/lib/discord-channel-types';
+import { Shop } from '@/lib/shop-types';
+
+export default function NewDiscordChannelPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+
+  const [channelName, setChannelName] = useState('');
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [shopId, setShopId] = useState('');
+  const [minSeverity, setMinSeverity] = useState<DiscordSeverity>('warning');
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/login');
+      return;
+    }
+    if (user) {
+      api.listShops().then(setShops).catch(() => undefined);
+    }
+  }, [authLoading, user, router]);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const channel = await api.createDiscordChannel({
+        channelName,
+        webhookUrl,
+        shopId: shopId || undefined,
+        minSeverity,
+      });
+      router.push(`/discord-channels/${channel.id}`);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to create channel');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center bg-zinc-50 dark:bg-black">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-lg space-y-4 rounded-lg border border-black/[.08] bg-white p-8 dark:border-white/[.12] dark:bg-zinc-900"
+      >
+        <h1 className="text-2xl font-semibold text-black dark:text-zinc-50">
+          Add Discord channel
+        </h1>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Channel name</span>
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={channelName}
+            onChange={(e) => setChannelName(e.target.value)}
+            placeholder="alerts-prod"
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Webhook URL</span>
+          <input
+            type="url"
+            required
+            pattern="https://.*"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+            placeholder="https://discord.com/api/webhooks/..."
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-xs text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+          <span className="block text-xs text-zinc-500">
+            Stored in a Kubernetes Secret, never in the platform database.
+          </span>
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Attach to shop</span>
+          <select
+            value={shopId}
+            onChange={(e) => setShopId(e.target.value)}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          >
+            <option value="">All my shops (namespace-wide)</option>
+            {shops.map((shop) => (
+              <option key={shop.id} value={shop.id}>
+                {shop.displayName} ({shop.host})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Minimum severity</span>
+          <select
+            value={minSeverity}
+            onChange={(e) => setMinSeverity(e.target.value as DiscordSeverity)}
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          >
+            <option value="info">info (everything)</option>
+            <option value="warning">warning</option>
+            <option value="critical">critical only</option>
+          </select>
+        </label>
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex-1 rounded bg-foreground py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+          >
+            {submitting ? 'Creating...' : 'Create channel'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/discord-channels')}
+            className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/discord-channels/page.tsx
+++ b/frontend/src/app/discord-channels/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import {
+  DiscordChannel,
+  discordPhaseColorClass,
+} from '@/lib/discord-channel-types';
+
+export default function DiscordChannelsListPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [channels, setChannels] = useState<DiscordChannel[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    const refresh = () => {
+      api
+        .listDiscordChannels()
+        .then(setChannels)
+        .catch((err) => {
+          if (err instanceof ApiError) setError(err.message);
+          else setError('Failed to load Discord channels');
+        });
+    };
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router]);
+
+  if (authLoading || (!user && !error)) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-4xl px-8 py-12">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+            Discord channels
+          </h1>
+          <Link
+            href="/discord-channels/new"
+            className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          >
+            + New channel
+          </Link>
+        </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        {channels === null ? (
+          <p className="text-sm text-zinc-500">Loading channels...</p>
+        ) : channels.length === 0 ? (
+          <div className="rounded border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-700">
+            <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+              No Discord channels yet. Add one to receive alerts.
+            </p>
+            <Link
+              href="/discord-channels/new"
+              className="inline-block rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+            >
+              Create your first channel
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {channels.map((channel) => (
+              <li
+                key={channel.id}
+                className="rounded border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <Link href={`/discord-channels/${channel.id}`} className="block">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-lg font-medium text-black dark:text-zinc-50">
+                        {channel.channelName}
+                      </h2>
+                      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                        {channel.shopId
+                          ? 'Scoped to one shop'
+                          : 'All shops in namespace'}
+                      </p>
+                    </div>
+                    <span
+                      className={`rounded px-2 py-1 text-xs font-medium ${discordPhaseColorClass(channel.lastKnownPhase)}`}
+                    >
+                      {channel.lastKnownPhase ?? 'Pending'}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex gap-3 text-xs text-zinc-500">
+                    <span>severity ≥ {channel.minSeverity}</span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { AuthProvider } from '@/lib/auth-context';
+import { AuthenticatedNav } from '@/lib/authenticated-nav';
 import { Web3Provider } from '@/lib/web3-provider';
 import './globals.css';
 
@@ -31,7 +32,10 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col" suppressHydrationWarning>
         <Web3Provider>
-          <AuthProvider>{children}</AuthProvider>
+          <AuthProvider>
+            <AuthenticatedNav />
+            {children}
+          </AuthProvider>
         </Web3Provider>
       </body>
     </html>

--- a/frontend/src/app/shops/new/page.tsx
+++ b/frontend/src/app/shops/new/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useEffect, useState } from 'react';
 import { ApiError, api } from '@/lib/api-client';
 import { useAuth } from '@/lib/auth-context';
 import { AvailabilityTier, DatabaseTier } from '@/lib/shop-types';
+import { Wallet } from '@/lib/wallet-types';
 
 export default function NewShopPage() {
   const router = useRouter();
@@ -16,14 +18,30 @@ export default function NewShopPage() {
   const [databaseTier, setDatabaseTier] = useState<DatabaseTier>('standard');
   const [walletAddress, setWalletAddress] = useState('');
   const [chainId, setChainId] = useState(11155111);
+  const [wallets, setWallets] = useState<Wallet[]>([]);
+  const [selectedWalletId, setSelectedWalletId] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !user) {
       router.push('/login');
+      return;
+    }
+    if (user) {
+      api.listWallets().then(setWallets).catch(() => undefined);
     }
   }, [authLoading, user, router]);
+
+  const onPickWallet = (id: string) => {
+    setSelectedWalletId(id);
+    if (!id) return;
+    const picked = wallets.find((w) => w.id === id);
+    if (picked) {
+      setWalletAddress(picked.address);
+      setChainId(Number(picked.chainId));
+    }
+  };
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -115,6 +133,33 @@ export default function NewShopPage() {
           </label>
         </div>
 
+        {wallets.length > 0 && (
+          <label className="block space-y-1 text-sm">
+            <span className="text-zinc-700 dark:text-zinc-300">
+              Use one of my wallets
+            </span>
+            <select
+              value={selectedWalletId}
+              onChange={(e) => onPickWallet(e.target.value)}
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            >
+              <option value="">(enter address manually below)</option>
+              {wallets.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.displayName} - {w.address.slice(0, 10)}... (chain {w.chainId})
+                </option>
+              ))}
+            </select>
+            <span className="block text-xs text-zinc-500">
+              Picking a wallet pre-fills address and chain ID. You can also{' '}
+              <Link href="/wallets/new" className="underline">
+                add a new wallet
+              </Link>{' '}
+              first.
+            </span>
+          </label>
+        )}
+
         <label className="block space-y-1 text-sm">
           <span className="text-zinc-700 dark:text-zinc-300">Wallet address (EVM)</span>
           <input
@@ -122,7 +167,10 @@ export default function NewShopPage() {
             required
             pattern="^0x[a-fA-F0-9]{40}$"
             value={walletAddress}
-            onChange={(e) => setWalletAddress(e.target.value)}
+            onChange={(e) => {
+              setWalletAddress(e.target.value);
+              setSelectedWalletId('');
+            }}
             placeholder="0xabc..."
             className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
           />

--- a/frontend/src/app/wallets/[id]/page.tsx
+++ b/frontend/src/app/wallets/[id]/page.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import {
+  Wallet,
+  WalletPurpose,
+  walletPhaseColorClass,
+} from '@/lib/wallet-types';
+
+const editInputClass =
+  'w-full rounded border border-zinc-300 bg-white px-2 py-1 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100';
+
+export default function WalletDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [wallet, setWallet] = useState<Wallet | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const id = params.id;
+
+  const fetchWallet = useCallback(() => {
+    api
+      .getWallet(id)
+      .then(setWallet)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) {
+          setError('Wallet not found');
+        } else if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to load wallet');
+        }
+      });
+  }, [id]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    fetchWallet();
+    const interval = setInterval(() => {
+      if (!editing) fetchWallet();
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router, fetchWallet, editing]);
+
+  const onDelete = async () => {
+    if (!wallet) return;
+    if (!window.confirm(`Delete wallet "${wallet.displayName}"?`)) return;
+    setDeleting(true);
+    try {
+      await api.deleteWallet(wallet.id);
+      router.push('/wallets');
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to delete wallet');
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+  if (error && !wallet) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+      </div>
+    );
+  }
+  if (!wallet) {
+    return <div className="p-8 text-zinc-500">Loading wallet...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-3xl px-8 py-12">
+        <div className="mb-2 text-sm text-zinc-500">
+          <button
+            type="button"
+            onClick={() => router.push('/wallets')}
+            className="underline"
+          >
+            ← All wallets
+          </button>
+        </div>
+
+        <div className="mb-6 flex items-start justify-between">
+          <div className="min-w-0 flex-1">
+            <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+              {wallet.displayName}
+            </h1>
+            <p className="mt-1 break-all font-mono text-xs text-zinc-600 dark:text-zinc-400">
+              {wallet.address}
+            </p>
+          </div>
+          <span
+            className={`ml-3 shrink-0 rounded px-3 py-1 text-sm font-medium ${walletPhaseColorClass(wallet.lastKnownPhase)}`}
+          >
+            {wallet.lastKnownPhase ?? 'Pending'}
+          </span>
+        </div>
+
+        {editing ? (
+          <EditPanel
+            wallet={wallet}
+            onCancel={() => setEditing(false)}
+            onSaved={(updated) => {
+              setWallet(updated);
+              setEditing(false);
+            }}
+            onError={setError}
+            externalError={error}
+          />
+        ) : (
+          <>
+            <dl className="grid grid-cols-2 gap-4 rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <Field label="Purpose">{wallet.purpose}</Field>
+              <Field label="Chain ID">{wallet.chainId}</Field>
+              <Field label="Created">
+                {new Date(wallet.createdAt).toLocaleString()}
+              </Field>
+              <Field label="K8s name">
+                <span className="font-mono text-xs">{wallet.k8sName}</span>
+              </Field>
+            </dl>
+
+            {error && (
+              <p className="mt-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+            )}
+
+            <div className="mt-6 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  setEditing(true);
+                }}
+                className="rounded border border-zinc-300 px-4 py-2 text-sm hover:bg-black/[.04] dark:border-zinc-700 dark:hover:bg-white/[.04]"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={deleting}
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? 'Deleting...' : 'Delete wallet'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditPanel({
+  wallet,
+  onCancel,
+  onSaved,
+  onError,
+  externalError,
+}: {
+  wallet: Wallet;
+  onCancel: () => void;
+  onSaved: (updated: Wallet) => void;
+  onError: (msg: string | null) => void;
+  externalError: string | null;
+}) {
+  const [displayName, setDisplayName] = useState(wallet.displayName);
+  const [purpose, setPurpose] = useState<WalletPurpose>(wallet.purpose);
+  const [saving, setSaving] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    onError(null);
+    try {
+      const updated = await api.updateWallet(wallet.id, {
+        displayName,
+        purpose,
+      });
+      onSaved(updated);
+    } catch (err) {
+      onError(err instanceof ApiError ? err.message : 'Failed to save changes');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="rounded border border-zinc-200 bg-white p-6 text-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Display name">
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className={editInputClass}
+          />
+        </Field>
+        <Field label="Purpose">
+          <select
+            value={purpose}
+            onChange={(e) => setPurpose(e.target.value as WalletPurpose)}
+            className={editInputClass}
+          >
+            <option value="payments">payments</option>
+            <option value="payout">payout</option>
+          </select>
+        </Field>
+        <Field label="Address (read-only)">
+          <span className="break-all font-mono text-xs text-zinc-500">
+            {wallet.address}
+          </span>
+        </Field>
+        <Field label="Chain ID (read-only)">
+          <span className="text-zinc-500">{wallet.chainId}</span>
+        </Field>
+      </div>
+
+      {externalError && (
+        <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+          {externalError}
+        </p>
+      )}
+
+      <div className="mt-6 flex gap-3">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+        >
+          {saving ? 'Saving...' : 'Save changes'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-black dark:text-zinc-100">{children}</dd>
+    </div>
+  );
+}

--- a/frontend/src/app/wallets/new/page.tsx
+++ b/frontend/src/app/wallets/new/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import { WalletPurpose } from '@/lib/wallet-types';
+
+export default function NewWalletPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+
+  const [displayName, setDisplayName] = useState('');
+  const [address, setAddress] = useState('');
+  const [chainId, setChainId] = useState(11155111);
+  const [purpose, setPurpose] = useState<WalletPurpose>('payments');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/login');
+    }
+  }, [authLoading, user, router]);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const wallet = await api.createWallet({
+        displayName,
+        address,
+        chainId,
+        purpose,
+      });
+      router.push(`/wallets/${wallet.id}`);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to create wallet');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center bg-zinc-50 dark:bg-black">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-lg space-y-4 rounded-lg border border-black/[.08] bg-white p-8 dark:border-white/[.12] dark:bg-zinc-900"
+      >
+        <h1 className="text-2xl font-semibold text-black dark:text-zinc-50">
+          Add wallet
+        </h1>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Display name</span>
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Main payments wallet"
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-700 dark:text-zinc-300">Address (EVM)</span>
+          <input
+            type="text"
+            required
+            pattern="^0x[a-fA-F0-9]{40}$"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            placeholder="0xabc..."
+            className="w-full rounded border border-zinc-300 bg-white px-3 py-2 font-mono text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          />
+          <span className="block text-xs text-zinc-500">
+            Paste an existing wallet address. Address and chain are immutable
+            after creation.
+          </span>
+        </label>
+
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <label className="block space-y-1">
+            <span className="text-zinc-700 dark:text-zinc-300">Chain ID</span>
+            <input
+              type="number"
+              min={1}
+              value={chainId}
+              onChange={(e) => setChainId(Number(e.target.value))}
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            />
+            <span className="block text-xs text-zinc-500">
+              Default 11155111 (Sepolia).
+            </span>
+          </label>
+
+          <label className="block space-y-1">
+            <span className="text-zinc-700 dark:text-zinc-300">Purpose</span>
+            <select
+              value={purpose}
+              onChange={(e) => setPurpose(e.target.value as WalletPurpose)}
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-black dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            >
+              <option value="payments">payments (receive buyer funds)</option>
+              <option value="payout">payout (platform payouts to you)</option>
+            </select>
+          </label>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex-1 rounded bg-foreground py-2 text-sm font-medium text-background hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+          >
+            {submitting ? 'Adding...' : 'Add wallet'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/wallets')}
+            className="rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/wallets/page.tsx
+++ b/frontend/src/app/wallets/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { ApiError, api } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth-context';
+import { Wallet, walletPhaseColorClass } from '@/lib/wallet-types';
+
+export default function WalletsListPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const [wallets, setWallets] = useState<Wallet[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    const refresh = () => {
+      api
+        .listWallets()
+        .then(setWallets)
+        .catch((err) => {
+          if (err instanceof ApiError) setError(err.message);
+          else setError('Failed to load wallets');
+        });
+    };
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => clearInterval(interval);
+  }, [authLoading, user, router]);
+
+  if (authLoading || (!user && !error)) {
+    return <div className="p-8 text-zinc-500">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-zinc-50 dark:bg-black">
+      <div className="mx-auto w-full max-w-4xl px-8 py-12">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-3xl font-semibold text-black dark:text-zinc-50">
+            My wallets
+          </h1>
+          <Link
+            href="/wallets/new"
+            className="rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          >
+            + New wallet
+          </Link>
+        </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        {wallets === null ? (
+          <p className="text-sm text-zinc-500">Loading wallets...</p>
+        ) : wallets.length === 0 ? (
+          <div className="rounded border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-700">
+            <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+              No wallets yet. Add one to receive payments or payouts.
+            </p>
+            <Link
+              href="/wallets/new"
+              className="inline-block rounded bg-foreground px-4 py-2 text-sm font-medium text-background hover:bg-[#383838] dark:hover:bg-[#ccc]"
+            >
+              Add your first wallet
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {wallets.map((wallet) => (
+              <li
+                key={wallet.id}
+                className="rounded border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <Link href={`/wallets/${wallet.id}`} className="block">
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0 flex-1">
+                      <h2 className="text-lg font-medium text-black dark:text-zinc-50">
+                        {wallet.displayName}
+                      </h2>
+                      <p className="break-all font-mono text-xs text-zinc-600 dark:text-zinc-400">
+                        {wallet.address}
+                      </p>
+                    </div>
+                    <span
+                      className={`ml-3 shrink-0 rounded px-2 py-1 text-xs font-medium ${walletPhaseColorClass(wallet.lastKnownPhase)}`}
+                    >
+                      {wallet.lastKnownPhase ?? 'Pending'}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex gap-3 text-xs text-zinc-500">
+                    <span>chain: {wallet.chainId}</span>
+                    <span>purpose: {wallet.purpose}</span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,5 +1,15 @@
 import { authStorage, StoredUser } from './auth-storage';
+import {
+  CreateDiscordChannelRequest,
+  DiscordChannel,
+  UpdateDiscordChannelRequest,
+} from './discord-channel-types';
 import { CreateShopRequest, Shop, UpdateShopRequest } from './shop-types';
+import {
+  CreateWalletRequest,
+  UpdateWalletRequest,
+  Wallet,
+} from './wallet-types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
 
@@ -96,5 +106,52 @@ export const api = {
   },
   deleteShop(id: string): Promise<void> {
     return request<void>(`/shops/${id}`, { method: 'DELETE' });
+  },
+  listDiscordChannels(): Promise<DiscordChannel[]> {
+    return request<DiscordChannel[]>('/discord-channels');
+  },
+  getDiscordChannel(id: string): Promise<DiscordChannel> {
+    return request<DiscordChannel>(`/discord-channels/${id}`);
+  },
+  createDiscordChannel(
+    payload: CreateDiscordChannelRequest,
+  ): Promise<DiscordChannel> {
+    return request<DiscordChannel>('/discord-channels', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+  updateDiscordChannel(
+    id: string,
+    payload: UpdateDiscordChannelRequest,
+  ): Promise<DiscordChannel> {
+    return request<DiscordChannel>(`/discord-channels/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  },
+  deleteDiscordChannel(id: string): Promise<void> {
+    return request<void>(`/discord-channels/${id}`, { method: 'DELETE' });
+  },
+  listWallets(): Promise<Wallet[]> {
+    return request<Wallet[]>('/wallets');
+  },
+  getWallet(id: string): Promise<Wallet> {
+    return request<Wallet>(`/wallets/${id}`);
+  },
+  createWallet(payload: CreateWalletRequest): Promise<Wallet> {
+    return request<Wallet>('/wallets', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+  updateWallet(id: string, payload: UpdateWalletRequest): Promise<Wallet> {
+    return request<Wallet>(`/wallets/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  },
+  deleteWallet(id: string): Promise<void> {
+    return request<void>(`/wallets/${id}`, { method: 'DELETE' });
   },
 };

--- a/frontend/src/lib/authenticated-nav.tsx
+++ b/frontend/src/lib/authenticated-nav.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from './auth-context';
+
+const tabs = [
+  { href: '/shops', label: 'Shops' },
+  { href: '/discord-channels', label: 'Discord channels' },
+  { href: '/wallets', label: 'Wallets' },
+];
+
+/**
+ * Top navigation rendered only when the user is logged in. Pages that need
+ * a clean full-screen layout (login, register) still get a no-op render
+ * because the user is null there.
+ */
+export function AuthenticatedNav() {
+  const { user, isLoading, logout } = useAuth();
+  const pathname = usePathname();
+
+  if (isLoading || !user) return null;
+
+  return (
+    <nav className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-8 py-3">
+        <div className="flex items-center gap-6">
+          <Link
+            href="/shops"
+            className="text-sm font-semibold text-black dark:text-zinc-50"
+          >
+            ShopHub
+          </Link>
+          <ul className="flex gap-4 text-sm">
+            {tabs.map((tab) => {
+              const active =
+                pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+              return (
+                <li key={tab.href}>
+                  <Link
+                    href={tab.href}
+                    className={
+                      active
+                        ? 'text-black underline underline-offset-4 dark:text-zinc-50'
+                        : 'text-zinc-600 hover:text-black dark:text-zinc-400 dark:hover:text-zinc-100'
+                    }
+                  >
+                    {tab.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-zinc-500">{user.email ?? user.walletAddress}</span>
+          <button
+            type="button"
+            onClick={logout}
+            className="rounded border border-zinc-300 px-3 py-1 text-xs hover:bg-black/[.04] dark:border-zinc-700 dark:hover:bg-white/[.04]"
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/lib/discord-channel-types.ts
+++ b/frontend/src/lib/discord-channel-types.ts
@@ -1,0 +1,46 @@
+export type DiscordSeverity = 'info' | 'warning' | 'critical';
+export type DiscordChannelPhase =
+  | 'Pending'
+  | 'Ready'
+  | 'Failed'
+  | 'Terminating';
+
+export interface DiscordChannel {
+  id: string;
+  userId: string;
+  shopId: string | null;
+  k8sName: string;
+  secretName: string;
+  channelName: string;
+  minSeverity: DiscordSeverity;
+  lastKnownPhase: DiscordChannelPhase | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDiscordChannelRequest {
+  channelName: string;
+  webhookUrl: string;
+  shopId?: string;
+  minSeverity?: DiscordSeverity;
+}
+
+export interface UpdateDiscordChannelRequest {
+  channelName?: string;
+  webhookUrl?: string;
+  shopId?: string | null;
+  minSeverity?: DiscordSeverity;
+}
+
+export function discordPhaseColorClass(phase: DiscordChannelPhase | null): string {
+  switch (phase) {
+    case 'Ready':
+      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+    case 'Failed':
+      return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+    case 'Terminating':
+      return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100';
+    default:
+      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200';
+  }
+}

--- a/frontend/src/lib/wallet-types.ts
+++ b/frontend/src/lib/wallet-types.ts
@@ -1,0 +1,40 @@
+export type WalletPurpose = 'payments' | 'payout';
+export type WalletPhase = 'Pending' | 'Ready' | 'Failed' | 'Terminating';
+
+export interface Wallet {
+  id: string;
+  userId: string;
+  k8sName: string;
+  displayName: string;
+  address: string;
+  chainId: string;
+  purpose: WalletPurpose;
+  lastKnownPhase: WalletPhase | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWalletRequest {
+  displayName: string;
+  address: string;
+  chainId?: number;
+  purpose?: WalletPurpose;
+}
+
+export interface UpdateWalletRequest {
+  displayName?: string;
+  purpose?: WalletPurpose;
+}
+
+export function walletPhaseColorClass(phase: WalletPhase | null): string {
+  switch (phase) {
+    case 'Ready':
+      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
+    case 'Failed':
+      return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100';
+    case 'Terminating':
+      return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100';
+    default:
+      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200';
+  }
+}


### PR DESCRIPTION
## Summary

Implements shophub#12 - the panel now lets users manage the two non-shop resources from the spec: **Discord channels** (alert webhooks) and **wallets** (EVM payment/payout addresses). Both surfaces follow the same shape as the existing Shop CRUD from #11: a database row in the platform DB plus a custom resource in the tenant namespace, reconciled by the shop-operator (CRDs from shop-operator#8 and #9).

**Discord channels.** A new module `discord-channels/` provides full CRUD scoped to the authenticated user. The webhook URL itself never lands in the platform database: on create the service writes it into a Kubernetes Secret in `shophub-tenants`, then creates a `DiscordChannel` CR whose `webhookSecretRef` points at that Secret. Rotation re-patches the Secret's `stringData`. Deletion unwinds the CR, the Secret, and the DB row in that order. The DB row carries `shopId` as a nullable FK to `shops(id)` with `ON DELETE SET NULL`, so deleting a shop never orphans a channel - the channel just reverts to "all shops in namespace" routing.

**Wallets.** A new module `wallets/` is a simpler shape: there is no Secret, the Wallet CR is purely declarative metadata (`address`, `chainId`, `purpose`, `displayName`). `address` and `chainId` are immutable after creation - they form the wallet's identity; users who want a different address create a new record.

**Frontend.** Six new pages (`/wallets`, `/wallets/new`, `/wallets/[id]`, plus the three Discord equivalents) mirror the existing `/shops` layout: list view with auto-refresh, create form with HTML5 validation, detail view with inline edit panel and delete. A new `AuthenticatedNav` component renders a top nav with three tabs (`Shops`, `Discord channels`, `Wallets`) once the user is logged in, plus a logout button; the login and register screens stay clean because the nav is gated on auth state. `/shops/new` learns a new optional "Use one of my wallets" dropdown that prefills `walletAddress` and `chainId` from a chosen Wallet - manual entry still works and clearing the address de-selects the dropdown.

## Test plan

- [x] `npm run build` and `npm test` pass in `backend/`
- [x] `npm run build` and `npm run lint` pass in `frontend/`
- [x] `npm run migration:run` applies the two new migrations cleanly (`AddDiscordChannelsTable`, `AddWalletsTable`)
- [x] Wallet CRUD works end to end against a real cluster
- [x] DiscordChannel CRUD works end to end, including webhook rotation
- [x] Deleting a Shop that is attached to a DiscordChannel does not delete the channel (FK `ON DELETE SET NULL`)
- [x] DTO-level validation rejects invalid EVM addresses, non-HTTPS webhook URLs, and unknown severities

Closes #12