### PR TITLE
fix: serve /metrics with the Prometheus content type and fix health check host

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,9 @@ USER node
 
 EXPOSE 3000
 
+# 127.0.0.1, not localhost: the server binds 0.0.0.0 (IPv4 only), while
+# localhost resolves to ::1 first, so the probe would be refused.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --quiet --spider http://localhost:3000/health || exit 1
+  CMD wget --quiet --spider http://127.0.0.1:3000/health || exit 1
 
 CMD ["node", "dist/main"]

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Header } from '@nestjs/common';
 import { AppService } from './app.service';
 import { register } from './observability/metrics';
 
@@ -16,7 +16,11 @@ export class AppController {
     return { status: 'ok' };
   }
 
+  // Prometheus rejects a scrape whose Content-Type it does not recognise.
+  // Returning a plain string from Nest makes Express default to text/html,
+  // so the exposition format has to be declared explicitly.
   @Get('/metrics')
+  @Header('Content-Type', register.contentType)
   async metrics() {
     return register.metrics();
   }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,7 +33,9 @@ COPY --from=builder /app/.next/static ./.next/static
 USER node
 EXPOSE 3000
 
+# 127.0.0.1, not localhost: the server binds 0.0.0.0 (IPv4 only), while
+# localhost resolves to ::1 first, so the probe would be refused.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget --quiet --spider http://localhost:3000/ || exit 1
+  CMD wget --quiet --spider http://127.0.0.1:3000/ || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

Same two defects as in the `shop` repository, found while wiring up scraping on a cluster.

## Related issue

Closes #

## Spec reference

4.1 (per-application metrics)

## Changes

- **`/metrics` now declares `Content-Type: text/plain; version=0.0.4`.** Returning a plain
  string from Nest makes Express default to `text/html`, which Prometheus rejects outright
  (`received unsupported Content-Type`), so no metric from the panel was ever collected.
- **Health checks probe `127.0.0.1` instead of `localhost`.** The servers bind `0.0.0.0`
  (IPv4 only) while `localhost` resolves to `::1` first, so the probe was refused and the
  container reported `unhealthy` while serving traffic normally.

## Testing

- `npm test` passes (38 tests, 6 suites).
- Deployed to a kind cluster: the panel starts, connects to Kubernetes in-cluster, and
  `/metrics` returns the Prometheus exposition format with the correct content type.

## Checklist

- [x] Commits follow Conventional Commits format
- [ ] Tests added or updated
- [x] Documentation updated if relevant
- [ ] Linked to related issue
